### PR TITLE
Allow user to define a list of the files to be parsed for tags.

### DIFF
--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -57,6 +57,7 @@ else
     endif
 endif
 
+
 redir => s:ftype_out
 silent filetype
 redir END
@@ -111,6 +112,10 @@ endif
 
 if !exists('g:tagbar_systemenc')
     let g:tagbar_systemenc = &encoding
+endif
+
+if !exists('g:tagbar_ctags_use_tagfiles')
+    let g:tagbar_ctags_use_tagfiles = 0
 endif
 
 if has('multi_byte') && has('unix') && &encoding == 'utf-8' &&
@@ -1676,7 +1681,14 @@ function! s:ExecuteCtagsOnFile(fname, ftype)
         let ctags_bin = g:tagbar_ctags_bin
     endif
 
-    let ctags_cmd = s:EscapeCtagsCmd(ctags_bin, ctags_args, a:fname)
+    let tagfiles_file=getcwd() . '/tag_files'
+    if g:tagbar_ctags_use_tagfiles && filereadable(tagfiles_file)
+        let ctags_args .= ' -L ' . tagfiles_file . ' '
+        let ctags_cmd = s:EscapeCtagsCmd(ctags_bin, ctags_args)
+    else
+        let ctags_cmd = s:EscapeCtagsCmd(ctags_bin, ctags_args, a:fname)
+    endif
+
     if ctags_cmd == ''
         return ''
     endif


### PR DESCRIPTION
Allowing user to define a tag_files at the root of a project which lists the files to be parsed for tags. This is toggle-able with g:tagbar_ctags_use_tagfiles and essentially adds ' -L ' . getcwd() . '/tag_files' to ctags_args if such a file exists and the option is set to 1.
