### PR TITLE
Ignore /doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
Hello mr. @majutsushi,
Obviously this is just a suggestion. I have added tagbar as a submodule of my vimfiles repo and it complains that the tagbar submodule has untracked content. I have pathogen managing my plugins (as well as you have) and I thought that maybe one of the reasons why you haven't ignored the tags files is because some users have their plugins directly inside the .vim folders. Maybe. Although, it doesn't make much sense, right? I am questioning it because I have started coding a vim plugin this week and I have added a .gitignore file to it. If there is any other reason, please, tell me so I can make better decisions in my project.
Regards
