### PR TITLE
Move script to autoload

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -22,97 +22,6 @@
 
 " Basic init {{{2
 
-if v:version < 700
-    echomsg 'Tagbar: Vim version is too old, Tagbar requires at least 7.0'
-    finish
-endif
-
-if !exists('g:tagbar_ctags_bin')
-    if executable('ctags-exuberant')
-        let g:tagbar_ctags_bin = 'ctags-exuberant'
-    elseif executable('exuberant-ctags')
-        let g:tagbar_ctags_bin = 'exuberant-ctags'
-    elseif executable('exctags')
-        let g:tagbar_ctags_bin = 'exctags'
-    elseif executable('ctags')
-        let g:tagbar_ctags_bin = 'ctags'
-    elseif executable('ctags.exe')
-        let g:tagbar_ctags_bin = 'ctags.exe'
-    elseif executable('tags')
-        let g:tagbar_ctags_bin = 'tags'
-    else
-        echomsg 'Tagbar: Exuberant ctags not found, skipping plugin'
-        finish
-    endif
-else
-    let g:tagbar_ctags_bin = expand(g:tagbar_ctags_bin)
-    if !executable(g:tagbar_ctags_bin)
-        echomsg 'Tagbar: Exuberant ctags not found in specified place,'
-              \ 'skipping plugin'
-        finish
-    endif
-endif
-
-redir => s:ftype_out
-silent filetype
-redir END
-if s:ftype_out !~# 'detection:ON'
-    echomsg 'Tagbar: Filetype detection is turned off, skipping plugin'
-    unlet s:ftype_out
-    finish
-endif
-unlet s:ftype_out
-
-let g:loaded_tagbar = 1
-
-if !exists('g:tagbar_left')
-    let g:tagbar_left = 0
-endif
-
-if !exists('g:tagbar_width')
-    let g:tagbar_width = 40
-endif
-
-if !exists('g:tagbar_autoclose')
-    let g:tagbar_autoclose = 0
-endif
-
-if !exists('g:tagbar_autofocus')
-    let g:tagbar_autofocus = 0
-endif
-
-if !exists('g:tagbar_sort')
-    let g:tagbar_sort = 1
-endif
-
-if !exists('g:tagbar_compact')
-    let g:tagbar_compact = 0
-endif
-
-if !exists('g:tagbar_expand')
-    let g:tagbar_expand = 0
-endif
-
-if !exists('g:tagbar_singleclick')
-    let g:tagbar_singleclick = 0
-endif
-
-if !exists('g:tagbar_foldlevel')
-    let g:tagbar_foldlevel = 99
-endif
-
-if !exists('g:tagbar_usearrows')
-    let g:tagbar_usearrows = 0
-endif
-
-if !exists('g:tagbar_autoshowtag')
-    let g:tagbar_autoshowtag = 0
-endif
-
-if !exists('g:tagbar_systemenc')
-    let g:tagbar_systemenc = &encoding
-endif
-
 if has('multi_byte') && has('unix') && &encoding == 'utf-8' &&
  \ (empty(&termencoding) || &termencoding == 'utf-8')
     let s:icon_closed = '▶'
@@ -135,8 +44,6 @@ let s:access_symbols = {
     \ 'protected' : '#',
     \ 'private'   : '-'
 \ }
-
-autocmd SessionLoadPost * nested call s:RestoreSession()
 
 " s:InitTypes() {{{2
 function! s:InitTypes()
@@ -2862,12 +2769,16 @@ function! tagbar#CloseWindow()
     call s:CloseWindow()
 endfunction
 
-function! tagbar#SetFoldLevel()
-    call s:SetFoldLevel(<args>)
+function! tagbar#SetFoldLevel(...)
+    call s:SetFoldLevel(a:1)
 endfunction
 
 function! tagbar#OpenParents()
     call s:OpenParents()
+endfunction
+
+function! tagbar#RestoreSession()
+    call s:RestoreSession()
 endfunction
 
 " Modeline {{{1

--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -26,6 +26,101 @@ if &cp || exists('g:loaded_tagbar')
     finish
 endif
 
+" Basic init {{{1
+
+if v:version < 700
+    echomsg 'Tagbar: Vim version is too old, Tagbar requires at least 7.0'
+    finish
+endif
+
+if !exists('g:tagbar_ctags_bin')
+    if executable('ctags-exuberant')
+        let g:tagbar_ctags_bin = 'ctags-exuberant'
+    elseif executable('exuberant-ctags')
+        let g:tagbar_ctags_bin = 'exuberant-ctags'
+    elseif executable('exctags')
+        let g:tagbar_ctags_bin = 'exctags'
+    elseif executable('ctags')
+        let g:tagbar_ctags_bin = 'ctags'
+    elseif executable('ctags.exe')
+        let g:tagbar_ctags_bin = 'ctags.exe'
+    elseif executable('tags')
+        let g:tagbar_ctags_bin = 'tags'
+    else
+        echomsg 'Tagbar: Exuberant ctags not found, skipping plugin'
+        finish
+    endif
+else
+    let g:tagbar_ctags_bin = expand(g:tagbar_ctags_bin)
+    if !executable(g:tagbar_ctags_bin)
+        echomsg 'Tagbar: Exuberant ctags not found in specified place,'
+              \ 'skipping plugin'
+        finish
+    endif
+endif
+
+redir => s:ftype_out
+silent filetype
+redir END
+if s:ftype_out !~# 'detection:ON'
+    echomsg 'Tagbar: Filetype detection is turned off, skipping plugin'
+    unlet s:ftype_out
+    finish
+endif
+unlet s:ftype_out
+
+let g:loaded_tagbar = 1
+
+if !exists('g:tagbar_left')
+    let g:tagbar_left = 0
+endif
+
+if !exists('g:tagbar_width')
+    let g:tagbar_width = 40
+endif
+
+if !exists('g:tagbar_autoclose')
+    let g:tagbar_autoclose = 0
+endif
+
+if !exists('g:tagbar_autofocus')
+    let g:tagbar_autofocus = 0
+endif
+
+if !exists('g:tagbar_sort')
+    let g:tagbar_sort = 1
+endif
+
+if !exists('g:tagbar_compact')
+    let g:tagbar_compact = 0
+endif
+
+if !exists('g:tagbar_expand')
+    let g:tagbar_expand = 0
+endif
+
+if !exists('g:tagbar_singleclick')
+    let g:tagbar_singleclick = 0
+endif
+
+if !exists('g:tagbar_foldlevel')
+    let g:tagbar_foldlevel = 99
+endif
+
+if !exists('g:tagbar_usearrows')
+    let g:tagbar_usearrows = 0
+endif
+
+if !exists('g:tagbar_autoshowtag')
+    let g:tagbar_autoshowtag = 0
+endif
+
+if !exists('g:tagbar_systemenc')
+    let g:tagbar_systemenc = &encoding
+endif
+
+autocmd SessionLoadPost * nested call tagbar#RestoreSession()
+
 " Commands {{{1
 command! -nargs=0 TagbarToggle        call tagbar#ToggleWindow()
 command! -nargs=0 TagbarOpen          call tagbar#OpenWindow(0)


### PR DESCRIPTION
Hi Jan,

In this pull request I move most of the code in plugin/tagbar.vim to autoload/tagbar.vim. With this change, Tagbar's load time at Vim startup decreases from 100 ms to less than 1 ms.

Please test it out and pull if you like.

Thanks!
