### PR TITLE
Tagbar adds unnecessary quotes around ctags_bin on Windows

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -3101,6 +3101,7 @@ function! s:EscapeCtagsCmd(ctags_bin, args, ...) abort
 
     " Stupid cmd.exe quoting
     if &shell =~ 'cmd\.exe'
+        let ctags_cmd = substitute(ctags_cmd, '"', '', 'g')
         let ctags_cmd = substitute(ctags_cmd, '\(&\|\^\)', '^\0', 'g')
     endif
 


### PR DESCRIPTION
I had a problem with tagbar trying to run ""coffeetags" --include-vars ... ". The quotes around coffeetags caused cmd.exe to look in the current directory for the coffeetags executable. This commit fixed it for me.
