### PR TITLE
Update example for statusline

### DIFF
--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -613,7 +613,7 @@ tagbar#currenttag({format}, {default} [, {flags}])
           other tags.
 
     For example, if you put the following into your statusline: >
-        %{tagbar#currenttag('[%s] ', '')}
+        %{tagbar#currenttag('[%s] ','')}
 <   then the function "myfunc" will be show as "[myfunc()] ".
 
 ==============================================================================


### PR DESCRIPTION
vim funcs can't have spaces in arg lists
