### PR TITLE
Pause autocmd functionality with :TagbarPause

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -45,7 +45,7 @@ let s:icon_open   = g:tagbar_iconchars[1]
 
 let s:type_init_done      = 0
 let s:autocommands_done   = 0
-let s:autocommands_enable = 0
+let s:autocommands_enabled = 0
 " 0: not checked yet; 1: checked and found; 2: checked and not found
 let s:checked_ctags       = 0
 let s:checked_ctags_types = 0
@@ -972,15 +972,15 @@ function! s:CreateAutocommands() abort
     augroup END
 
     let s:autocommands_done = 1
-    let s:autocommands_enable = 1
+    let s:autocommands_enabled = 1
 endfunction
 
 " s:PauseAutocommands() {{{2
 " Toggle autocommands 
 function! s:PauseAutocommands() abort
-    if s:autocommands_enable == 1
+    if s:autocommands_enabled == 1
         autocmd! TagbarAutoCmds
-        let s:autocommands_enable = 0
+        let s:autocommands_enabled = 0
     else
         call s:CreateAutocommands()
         call s:AutoUpdate(fnamemodify(expand('%'), ':p'), 0)

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -194,6 +194,13 @@ You can also use |:TagbarOpenAutoClose| to open the Tagbar window, jump to it
 and have it close automatically on tag selection regardless of the
 |g:tagbar_autoclose| setting.
 
+Pausing the Tagbar window~
+Use :TagbarTogglePause to toggle freezing the Tagbar window on its currently
+displayed file.  Freezing the window stops the Tagbar from changing when
+switching to a different source file.  All Tagbar functionality continues 
+to work as expected.  Unfreezing the window will cause it to load the current 
+source file.
+
 Jumping to tags~
 When you're inside the Tagbar window you can jump to the definition of a tag
 by moving the cursor to a tag and pressing <Enter> or double-clicking on it
@@ -259,6 +266,10 @@ COMMANDS                                                     *tagbar-commands*
 :TagbarOpenAutoClose                                    *:TagbarOpenAutoClose*
     Open the Tagbar window, jump to it and close it on tag selection. This is
     an alias for ":TagbarOpen fjc".
+
+:TagbarTogglePause                                        *:TagbarTogglePause*
+    Freezes/Unfreezes the Tagbar window.  Stops the contents of the window 
+    from changing when a different source file is selected.
 
 :TagbarSetFoldlevel[!] {number}                          *:TagbarSetFoldlevel*
     Set the foldlevel of the tags of the current file to {number}. The

--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -115,7 +115,7 @@ command! -nargs=? TagbarCurrentTag    echo tagbar#currenttag('%s', 'No current t
 command! -nargs=1 TagbarGetTypeConfig call tagbar#gettypeconfig(<f-args>)
 command! -nargs=? TagbarDebug         call tagbar#StartDebug(<f-args>)
 command! -nargs=0 TagbarDebugEnd      call tagbar#StopDebug()
-command! -nargs=0 TagbarPause         call tagbar#PauseAutocommands()
+command! -nargs=0 TagbarTogglePause   call tagbar#PauseAutocommands()
 
 " Modeline {{{1
 " vim: ts=8 sw=4 sts=4 et foldenable foldmethod=marker foldcolumn=1


### PR DESCRIPTION
tagbar#PauseAutocommands :TagbarPause

:TagbarPause pauses autocmds, effectively freezing Tagbar on the last
file.  Useful for keeping a tag reference for a file open whilst working
in a different file.
