### PR TITLE
Do not interfere window switching history

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -2389,7 +2389,14 @@ function! s:RenderContent(...) abort
         let in_tagbar = 1
     else
         let in_tagbar = 0
+        let currwinnr = winnr()
+
+        " Get the previous window number, so that we can reproduce
+        " the window entering history later. Do not run autocmd on
+        " this command, make sure nothing is interfering.
+        call s:winexec('noautocmd wincmd p')
         let prevwinnr = winnr()
+
         call s:winexec(tagbarwinnr . 'wincmd w')
     endif
 
@@ -2454,6 +2461,7 @@ function! s:RenderContent(...) abort
 
     if !in_tagbar
         call s:winexec(prevwinnr . 'wincmd w')
+        call s:winexec(currwinnr . 'wincmd w')
     endif
 endfunction
 


### PR DESCRIPTION
Many plugins rely on 'wincmd p' to work properly, we need to preserve at least one-level backwards window switching history.
