### PR TITLE
Refactor the mechanism used to quit vim if tagbar window is the last one

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -3327,7 +3327,11 @@ function! s:QuitIfOnlyWindow() abort
         if tabpagenr('$') == 1
             " Before quitting Vim, delete the tagbar buffer so that
             " the '0 mark is correctly set to the previous buffer.
-            bdelete
+            " Also disable autocmd on this command to avoid unnecessary
+            " autocmd nesting.
+            if winnr('$') == 1
+                noautocmd bdelete
+            endif
             quit
         else
             close


### PR DESCRIPTION
There might be other plugin windows but no normal file window open, we
need to make sure tagbar window is closed at this situation.

If there are other plugin windows open, close tagbar window and handle
over the control to the other window.

If the last file in the Vim's file arguments list has not been edited
yet, normal Vim's behavior would be quit on ':q!' or twice ':q'. As our
plugin window is the last window now, previously quiting on the file
window will not trigger the "more files" check, but our window does.
We'd better to behave the same. Currently, twice ':q' quiting would work,
but ':q!' not. There is no easy way to determine whether the command
being executed with a "!" or not, so this is a flaw now and we need
to come up a better solution someday, but it is a progress than before.
