### PR TITLE
Run auto-updating on BufReadPost event

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -960,7 +960,7 @@ function! s:CreateAutocommands() abort
         autocmd BufEnter   __Tagbar__ nested call s:QuitIfOnlyWindow()
         autocmd CursorHold __Tagbar__ call s:ShowPrototype(1)
 
-        autocmd BufWritePost * call
+        autocmd BufReadPost,BufWritePost * call
                     \ s:AutoUpdate(fnamemodify(expand('<afile>'), ':p'), 1)
         autocmd BufEnter,CursorHold,FileType * call
                     \ s:AutoUpdate(fnamemodify(expand('<afile>'), ':p'), 0)


### PR DESCRIPTION
If 'autoread' is set and a buffer gets updated, tagbar need to be
triggerd to update itself too.
