### PR TITLE
When switching to a buffer that is unsupported, clear current.

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -3056,6 +3056,7 @@ function! s:AutoUpdate(fname, force) abort
     " Don't do anything if the file isn't supported
     if !s:IsValidFile(a:fname, sftype)
         call s:LogDebugMessage('Not a valid file, stopping processing')
+        call s:known_files.setCurrent({})
         return
     endif
 


### PR DESCRIPTION
I'm not entirely sure this is the correct fix, but it seems to work.  I discovered this be editing a shell file that had some functions in it, and then switched to a buffer where I was editing ReStructuredText (the latter isn't supported by tagbar--and correctly).  But the status line was still showing me as being inside of the shell functions.  IOW, it was taking my current location from the current file but looking up data that was in the previous file I was editing.  So I think the current file needs to get reset to an empty collection, so that `s:GetNearbyTag()` stops looking for tags at all.
