### PR TITLE
Map C-j like Enter

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -922,6 +922,7 @@ function! s:MapKeys() abort
                             \ <LeftRelease><C-o>:call <SID>CheckMouseClick()<CR>
 
     nnoremap <script> <silent> <buffer> <CR>    :call <SID>JumpToTag(0)<CR>
+    nnoremap <script> <silent> <buffer> <C-j>   :call <SID>JumpToTag(0)<CR>
     nnoremap <script> <silent> <buffer> p       :call <SID>JumpToTag(1)<CR>
     nnoremap <script> <silent> <buffer> <Space> :call <SID>ShowPrototype(0)<CR>
 

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -308,7 +308,7 @@ KEY MAPPINGS                                                     *tagbar-keys*
 The following mappings are valid in the Tagbar window:
 
 <F1>          Display key mapping help.
-<CR>/<Enter>  Jump to the tag under the cursor. Doesn't work for pseudo-tags
+<C-j>/<Enter> Jump to the tag under the cursor. Doesn't work for pseudo-tags
               or generic headers.
 p             Jump to the tag under the cursor, but stay in the Tagbar window.
 <LeftMouse>   When on a fold icon, open or close the fold depending on the


### PR DESCRIPTION
I added a new map that works as Enter in many parts of Vim, and many other unix-applications, such as bash. This allows you not to take your hands off the standard hjkl-position.
