### PR TITLE
Enhancements and fixes for the syntax definitions.

### DIFF
--- a/syntax/tagbar.vim
+++ b/syntax/tagbar.vim
@@ -12,7 +12,7 @@ if exists("b:current_syntax")
 endif
 
 let s:ics= escape(join(g:tagbar_iconchars, ''), ']^\-')
-let s:pattern = '\(\S\@<![' . s:ics . '] \?\)\@<=[^-+: ]\+[^:]\+$'
+let s:pattern = '\(^[' . s:ics . '] \?\)\@<=[^-+: ]\+[^:]\+$'
 execute "syntax match TagbarKind '" . s:pattern . "'"
 
 let s:pattern = '\(\S\@<!' . s:ics . '][-+# ]\?\)\@<=[^*(]\+\(\*\?\(([^)]\+)\)\? :\)\@='


### PR DESCRIPTION
I found two instances of tags being incorrectly highlighted with the `TagbarKind` group:
- tags containing the sigil character (e.g. `-`)
- tags with visibility sigils and the default `+` / `-` icon chars on Windows.
