### PR TITLE
Fix for confusing font character example.

### DIFF
--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -493,7 +493,7 @@ Examples (don't worry if some of the characters aren't displayed correctly,
 just choose other characters in that case):
 >
         let g:tagbar_iconchars = ['▶', '▼']  (default on Linux and Mac OS X)
-        let g:tagbar_iconchars = ['▾', '▸']
+        let g:tagbar_iconchars = ['▸', '▾']
         let g:tagbar_iconchars = ['▷', '◢']
         let g:tagbar_iconchars = ['+', '-']  (default on Windows)
 <


### PR DESCRIPTION
A minor fix for a confusing (to me, at least) recommendation for font characters in the docs. (Feel free to ignore...thanks for the plugin!)
