### PR TITLE
specify a option is disable append mode

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -2131,7 +2131,8 @@ function! s:ExecuteCtagsOnFile(fname, realfname, typeinfo) abort
                           \ '--excmd=pattern',
                           \ '--fields=nksSa',
                           \ '--extra=',
-                          \ '--sort=no'
+                          \ '--sort=no',
+                          \ '--append=no'
                           \ ]
 
         " Include extra type definitions


### PR DESCRIPTION
I use MacOSX Marvericks and ctags is

```
$ ctags --version
Exuberant Ctags 5.8, Copyright (C) 1996-2009 Darren Hiebert
  Compiled: Apr 30 2014, 14:18:51
  Addresses: <dhiebert@users.sourceforge.net>, http://ctags.sourceforge.net
  Optional compiled features: +wildcards, +regex
```

When I use the command `TagbarToggle`, I got the error as below

```
Tagbar: Could not execute ctags for /var/folders/ks/w___zvl52wq8wl46csj4jgb00000gn/T/vT3yxLu/10.py!
Executed command: "'/usr/local/bin/ctags' '-f' '-' '--format=2' '--excmd=pattern' '--fields=nksSa' '--extra=' '--sort=no' '--language-force=python' '--python-kinds=icfmv' '/var/folders/ks/w___zvl52wq8wl46csj4jgb00000gn/T/vT3yxLu/10.py'"
Command output:
ctags: append mode is not compatible with tags to stdout
```

I can't see the whole, but this patch was solve my problem.
Thanks for the nice plugin!
