### PR TITLE
Error when using tagbar#currenttagtype() with Rust

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -3714,7 +3714,11 @@ function! tagbar#currenttagtype(fmt, default) abort
 
     let typeinfo = tag.fileinfo.typeinfo
     let plural = typeinfo.kinds[typeinfo.kinddict[kind]].long
-    let singular = s:singular_types[plural]
+    if has_key(plural)
+        let singular = s:singular_types[plural]
+    else
+        let singular = plural
+    endif
     return printf(a:fmt, singular)
 endfunction
 


### PR DESCRIPTION
I'm using `tagbar#currenttagtype()` to display the tag type in my status line. This works fine for C and C++ but fails with Rust. It seems that all `typeinfo.kinds` of universal ctags for Rust are already singular so getting the singular expression from the `s:singular_types` dictionary fails. As a fix I'm checking if the key is available in the dictionary before accessing it.

System information:

  * VIM - Vi IMproved 8.2 (2019 Dec 12, compiled May 18 2020 10:06:50) Included patches: 1-788
  * Universal Ctags 0.0.0(3f0ea94c)

For reference I printed the content of `typeinfo.kinds`:

```
[{'short': 'n', 'long': 'module', 'fold': 1, 'stl': 0}, {'short': 's', 'long': 'struct', 'fold': 0, 'stl': 1}, {'short': 'i', 'long': 'trait', 'fold': 0, 'stl': 1}, {'short': 'c', 'long': 'implementation', 'fold': 0, 'stl': 0}, {'short': 'f', 'long': 'function', 'fold': 0, 'stl': 1}, {'short': 'g', 'long': 'enum', 'fold': 0, 'stl': 1}, {'short': 't', 'long': 'type alias', 'fold': 0, 'stl': 1}, {'short': 'v', 'long': 'global variable', 'fold': 0, 'stl': 1}, {'short': 'M', 'long': 'macro', 'fold': 0, 'stl': 1}, {'short': 'm', 'long': 'struct field', 'fold': 0, 'stl': 1}, {'short': 'e', 'long': 'enum variant', 'fold': 0, 'stl': 1}, {'short': 'P', 'long': 'method', 'fold': 0, 'stl': 1}, {'short': '?', 'long': 'unknown', 'fold': 0, 'stl': 1}]
```
