### PR TITLE
Add option to not trigger update on large files

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1158,6 +1158,20 @@ function! s:ProcessFile(fname, ftype) abort
         return
     endif
 
+    " If the file size limit it set, then check the linecount to see if
+    " this file should be ignored or not.
+    if g:tagbar_file_size_limit > 0
+        let linecount = line('$')
+        if linecount > g:tagbar_file_size_limit && !exists('b:tagbar_force_update')
+            call tagbar#debug#log('[ProcessFile] File size too large (' . linecount . ' lines) - limit set to ' . g:tagbar_file_size_limit)
+            if !exists('b:tagbar_file_exceeds_limit')
+                echom 'File size too large (' . linecount . ' lines) - Not processing file (see help for g:tagbar_file_size_limit).'
+                let b:tagbar_file_exceeds_limit = 1
+            endif
+            return
+        endif
+    endif
+
     let typeinfo = s:known_types[a:ftype]
 
     " If the file has only been updated preserve the fold states, otherwise
@@ -3576,6 +3590,16 @@ endfunction
 " Trigger an AutoUpdate() of the currently opened file
 function! tagbar#Update() abort
     call s:AutoUpdate(fnamemodify(expand('%'), ':p'), 0)
+endfunction
+
+"  tagbar#ForceUpdate() {{{2
+function! tagbar#ForceUpdate() abort
+    if !exists('b:tagbar_force_update')
+        let b:tagbar_force_update = 1
+        call s:AutoUpdate(fnamemodify(expand('%'), ':p'), 1)
+        unlet b:tagbar_force_update
+        unlet b:tagbar_file_exceeds_limit
+    endif
 endfunction
 
 " tagbar#toggle_pause() {{{2

--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1158,14 +1158,16 @@ function! s:ProcessFile(fname, ftype) abort
         return
     endif
 
-    " If the file size limit it set, then check the linecount to see if
+    " If the file size limit it set, then check the file size to see if
     " this file should be ignored or not.
     if g:tagbar_file_size_limit > 0
-        let linecount = line('$')
+        let linecount = getfsize(expand('%'))
         if linecount > g:tagbar_file_size_limit && !exists('b:tagbar_force_update')
-            call tagbar#debug#log('[ProcessFile] File size too large (' . linecount . ' lines) - limit set to ' . g:tagbar_file_size_limit)
+            call tagbar#debug#log('[ProcessFile] File size too large (' . linecount .
+                        \ ' bytes) - limit set to ' . g:tagbar_file_size_limit)
             if !exists('b:tagbar_file_exceeds_limit')
-                echom 'File size too large (' . linecount . ' lines) - Not processing file (see help for g:tagbar_file_size_limit).'
+                echom 'File size too large (' . linecount .
+                            \ ' bytes) - Not processing file (see help for g:tagbar_file_size_limit).'
                 let b:tagbar_file_exceeds_limit = 1
             endif
             return

--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1161,12 +1161,12 @@ function! s:ProcessFile(fname, ftype) abort
     " If the file size limit it set, then check the file size to see if
     " this file should be ignored or not.
     if g:tagbar_file_size_limit > 0
-        let linecount = getfsize(expand('%'))
-        if linecount > g:tagbar_file_size_limit && !exists('b:tagbar_force_update')
-            call tagbar#debug#log('[ProcessFile] File size too large (' . linecount .
+        let fsize = getfsize(expand('%'))
+        if fsize > g:tagbar_file_size_limit && !exists('b:tagbar_force_update')
+            call tagbar#debug#log('[ProcessFile] File size too large (' . fsize .
                         \ ' bytes) - limit set to ' . g:tagbar_file_size_limit)
             if !exists('b:tagbar_file_exceeds_limit')
-                echom 'File size too large (' . linecount .
+                echom 'File size too large (' . fsize .
                             \ ' bytes) - Not processing file (see help for g:tagbar_file_size_limit).'
                 let b:tagbar_file_exceeds_limit = 1
             endif

--- a/autoload/tagbar/prototypes/fileinfo.vim
+++ b/autoload/tagbar/prototypes/fileinfo.vim
@@ -9,6 +9,9 @@ function! tagbar#prototypes#fileinfo#new(fname, ftype, typeinfo) abort
     " File modification time
     let newobj.mtime = getftime(a:fname)
 
+    " Get file size
+    let newobj.fsize = getfsize(a:fname)
+
     " The vim file type
     let newobj.ftype = a:ftype
 
@@ -51,6 +54,10 @@ function! tagbar#prototypes#fileinfo#new(fname, ftype, typeinfo) abort
     let newobj.sortTags = function(s:add_snr('s:sortTags'))
     let newobj.openKindFold = function(s:add_snr('s:openKindFold'))
     let newobj.closeKindFold = function(s:add_snr('s:closeKindFold'))
+
+    " This is used during file processing. If the limit is exceeded at that
+    " point, then mark this flag for displaying to the tagbar window
+    let newobj.fsize_exceeded = 0
 
     return newobj
 endfunction

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -891,7 +891,7 @@ g:tagbar_file_size_limit~
 Default: 0
 
 By default, all files are processed by tagbar. Setting this value to non-zero
-will disable processing for any file with a line count greater than
+will disable processing for any file with a byte count greater than
 |g:tagbar_file_size_limit|. A message will be displayed once for a given buffer
 if the limit is exceeded. The file can be forcefully updated with the
 |tagbar#ForceUpdate()| function. If the value is set to 0, then the file will

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -337,6 +337,10 @@ FUNCTIONS                                                   *tagbar-functions*
         return tag . ' --- ' . lines . ' lines'
     endfunction
 <
+*tagbar#ForceUpdate()*
+    Forcefully update a file even if it exceeds the |g:tagbar_file_size_limit|
+    value. This also clears the internal flags to the file will be re-examined
+    again.
 
 ------------------------------------------------------------------------------
 KEY MAPPINGS                                                     *tagbar-keys*
@@ -881,6 +885,21 @@ on disk rather than the current buffer written to a temporary file.
 Example:
 >
         let g:tagbar_use_cache = 0
+<
+                                                     *g:tagbar_file_size_limit*
+g:tagbar_file_size_limit~
+Default: 0
+
+By default, all files are processed by tagbar. Setting this value to non-zero
+will disable processing for any file with a line count greater than
+|g:tagbar_file_size_limit|. A message will be displayed once for a given buffer
+if the limit is exceeded. The file can be forcefully updated with the
+|tagbar#ForceUpdate()| function. If the value is set to 0, then the file will
+always be processed.
+
+Example:
+>
+    let g:tagbar_file_size_limit = 10000
 <
 
 ------------------------------------------------------------------------------

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -311,6 +311,12 @@ COMMANDS                                                     *tagbar-commands*
 :TagbarDebugEnd                                              *:TagbarDebugEnd*
     End debug mode, debug messages will no longer be written to the logfile.
 
+:TagbarForceUpdate                                        *:TagbarForceUpdate*
+    Forcefully update a file even if it exceeds the |g:tagbar_file_size_limit|
+    value. This will only work for one invocation of the file processing.
+    After the file is processed and tags are generated, then it will re-enable
+    the file size limit. So if the file is written and needs to be processed
+    again, this command will need to be re-executed.
 
 ------------------------------------------------------------------------------
 FUNCTIONS                                                   *tagbar-functions*
@@ -894,8 +900,8 @@ By default, all files are processed by tagbar. Setting this value to non-zero
 will disable processing for any file with a byte count greater than
 |g:tagbar_file_size_limit|. A message will be displayed once for a given buffer
 if the limit is exceeded. The file can be forcefully updated with the
-|tagbar#ForceUpdate()| function. If the value is set to 0, then the file will
-always be processed.
+|tagbar#ForceUpdate()| function or with the |:TagbarForceUpdate| command. If
+the value is set to 0, then the file will always be processed.
 
 Example:
 >

--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -91,6 +91,7 @@ function! s:setup_options() abort
         \ ['case_insensitive', 0],
         \ ['compact', 0],
         \ ['expand', 0],
+        \ ['file_size_limit', 0],
         \ ['foldlevel', 99],
         \ ['hide_nonpublic', 0],
         \ ['height', 10],

--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -181,6 +181,7 @@ command! -nargs=1 TagbarGetTypeConfig call tagbar#gettypeconfig(<f-args>)
 command! -nargs=? TagbarDebug         call tagbar#debug#start_debug(<f-args>)
 command! -nargs=0 TagbarDebugEnd      call tagbar#debug#stop_debug()
 command! -nargs=0 TagbarTogglePause   call tagbar#toggle_pause()
+command! -nargs=0 TagbarForceUpdate   call tagbar#ForceUpdate()
 
 " Modeline {{{1
 " vim: ts=8 sw=4 sts=4 et foldenable foldmethod=marker foldcolumn=1


### PR DESCRIPTION
New feature for #636 

Initial addition of large file support option. Just getting the ball rolling on this, but not fully implemented.

Looking to find a way to add output into tagbar window indicating that the file was ignored. Currently this will be displayed once in the vim messages history, but due to ordering of loading, the message isn't actually seen. I believe this is due to the messages history getting initialized after the plugins are loaded.

This adds an option `g:tagbar_file_size_limit` which can be set by the user to set a line count limit so the auto-update does not process anything on the file. This can be overridden by calling a new `tagbar#ForceUpdate()` routine