### PR TITLE
Add g:tagbar_visibility_symbols

### DIFF
--- a/autoload/tagbar/prototypes/basetag.vim
+++ b/autoload/tagbar/prototypes/basetag.vim
@@ -3,6 +3,9 @@ let s:visibility_symbols = {
     \ 'protected' : '#',
     \ 'private'   : '-'
 \ }
+if !empty(g:tagbar_visibility_symbols)
+    let s:visibility_symbols = g:tagbar_visibility_symbols
+endif
 
 function! tagbar#prototypes#basetag#new(name) abort
     let newobj = {}

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -646,7 +646,21 @@ name.
 Example:
 >
         let g:tagbar_show_visibility = 0
-<
+
+                                                  *g:tagbar_visibility_symbols*
+g:tagbar_visibility_symbols
+Default: { 'public' : '+', 'protected' : '#', 'private' : '-' }
+
+Symbols to use for visibility (public/protected/private) to the left of the tag
+name. See |g:tagbar_show_visibility|.
+
+Example:
+>
+        let g:tagbar_visibility_symbols = {
+            \ 'public'    : '+',
+            \ 'protected' : '#',
+            \ 'private'   : '-'
+            \ }
 
                                                    *g:tagbar_show_linenumbers*
 g:tagbar_show_linenumbers~

--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -109,11 +109,6 @@ function! s:setup_options() abort
         \ ['zoomwidth', 1],
         \ ['silent', 0],
         \ ['use_cache', 1],
-        \ ['visibility_symbols', {
-        \       'public'    : '+',
-        \       'protected' : '#',
-        \       'private'   : '-'
-        \ }],
         \ ['wrap', 0],
     \ ]
 

--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -109,6 +109,11 @@ function! s:setup_options() abort
         \ ['zoomwidth', 1],
         \ ['silent', 0],
         \ ['use_cache', 1],
+        \ ['visibility_symbols', {
+        \       'public'    : '+',
+        \       'protected' : '#',
+        \       'private'   : '-'
+        \ }],
         \ ['wrap', 0],
     \ ]
 


### PR DESCRIPTION
This adds `g:tagbar_visiblity_symbols` as a user-facing setting to override the use of `+/#/-` for `public/protected/private` visibility symbols.  If not specified by user, uses pre-existing defaults (`+/#/-`).
