### PR TITLE
Add g:tagbar_scopestrs

### DIFF
--- a/autoload/tagbar/prototypes/normaltag.vim
+++ b/autoload/tagbar/prototypes/normaltag.vim
@@ -1,3 +1,12 @@
+function! s:maybe_map_scope(kindstr)
+    if !empty(g:tagbar_scope_strs)
+        if has_key(g:tagbar_scope_strs, a:kindstr)
+            return g:tagbar_scope_strs[a:kindstr]
+        endif
+    endif
+    return a:kindstr
+endfunction
+
 function! tagbar#prototypes#normaltag#new(name) abort
     let newobj = tagbar#prototypes#basetag#new(a:name)
 
@@ -22,7 +31,8 @@ function! s:strfmt() abort dict
     if has_key(self.fields, 'type')
         let suffix .= ' : ' . self.fields.type
     elseif has_key(get(typeinfo, 'kind2scope', {}), self.fields.kind)
-        let suffix .= ' : ' . typeinfo.kind2scope[self.fields.kind]
+        let scope = s:maybe_map_scope(typeinfo.kind2scope[self.fields.kind])
+        let suffix .= ' : ' . scope
     endif
 
     return self._getPrefix() . self.name . suffix

--- a/autoload/tagbar/prototypes/normaltag.vim
+++ b/autoload/tagbar/prototypes/normaltag.vim
@@ -1,10 +1,10 @@
-function! s:maybe_map_scope(kindstr)
-    if !empty(g:tagbar_scope_strs)
-        if has_key(g:tagbar_scope_strs, a:kindstr)
-            return g:tagbar_scope_strs[a:kindstr]
+function! s:maybe_map_scope(scopestr) abort
+    if !empty(g:tagbar_scopestrs)
+        if has_key(g:tagbar_scopestrs, a:scopestr)
+            return g:tagbar_scopestrs[a:scopestr]
         endif
     endif
-    return a:kindstr
+    return a:scopestr
 endfunction
 
 function! tagbar#prototypes#normaltag#new(name) abort

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -734,6 +734,38 @@ just choose other characters in that case):
         let g:tagbar_iconchars = ['▷', '◢']
         let g:tagbar_iconchars = ['+', '-']  (default on Windows)
 <
+                                                          *g:tagbar_scope_strs*
+g:tagbar_scope_strs~
+Default: {}
+
+Setting to replace a tag's scope with a user-specified string in Tagbar's
+display. If a scope is found in the keys of |g:tagbar_scope_strs|, then the
+scope will be displayed as the corresponding value.  If the scope is not
+found, then the scope will be displayed as normal.
+
+Example (don't worry if some of the characters aren't displayed correctly,
+just choose other characters or strings in that case):
+>
+        let g:tagbar_scope_strs = {
+            \    'class': "\uf0e8",
+            \    'const': "\uf8ff",
+            \    'constant': "\uf8ff",
+            \    'enum': "\uf702",
+            \    'field': "\uf30b",
+            \    'func': "\uf794",
+            \    'function': "\uf794",
+            \    'getter': "\ufab6",
+            \    'implementation': "\uf776",
+            \    'interface': "\uf7fe",
+            \    'map': "\ufb44",
+            \    'member': "\uf02b",
+            \    'method': "\uf6a6",
+	    \    'setter': "\uf7a9",
+	    \    'variable': "\uf71b",
+            \ }
+
+
+<
 
                                                         *g:tagbar_autoshowtag*
 g:tagbar_autoshowtag~

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -734,19 +734,19 @@ just choose other characters in that case):
         let g:tagbar_iconchars = ['▷', '◢']
         let g:tagbar_iconchars = ['+', '-']  (default on Windows)
 <
-                                                          *g:tagbar_scope_strs*
-g:tagbar_scope_strs~
+                                                          *g:tagbar_scopestrs*
+g:tagbar_scopestrs~
 Default: {}
 
 Setting to replace a tag's scope with a user-specified string in Tagbar's
-display. If a scope is found in the keys of |g:tagbar_scope_strs|, then the
+display. If a scope is found in the keys of |g:tagbar_scopestrs|, then the
 scope will be displayed as the corresponding value.  If the scope is not
 found, then the scope will be displayed as normal.
 
 Example (don't worry if some of the characters aren't displayed correctly,
 just choose other characters or strings in that case):
 >
-        let g:tagbar_scope_strs = {
+        let g:tagbar_scopestrs = {
             \    'class': "\uf0e8",
             \    'const': "\uf8ff",
             \    'constant': "\uf8ff",
@@ -760,8 +760,8 @@ just choose other characters or strings in that case):
             \    'map': "\ufb44",
             \    'member': "\uf02b",
             \    'method': "\uf6a6",
-	    \    'setter': "\uf7a9",
-	    \    'variable': "\uf71b",
+            \    'setter': "\uf7a9",
+            \    'variable': "\uf71b",
             \ }
 
 

--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -95,7 +95,7 @@ function! s:setup_options() abort
         \ ['hide_nonpublic', 0],
         \ ['height', 10],
         \ ['indent', 2],
-        \ ['scope_strs', {}],
+        \ ['scopestrs', {}],
         \ ['left', 0],
         \ ['position', default_pos],
         \ ['previewwin_pos', previewwin_pos],

--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -95,6 +95,7 @@ function! s:setup_options() abort
         \ ['hide_nonpublic', 0],
         \ ['height', 10],
         \ ['indent', 2],
+        \ ['scope_strs', {}],
         \ ['left', 0],
         \ ['position', default_pos],
         \ ['previewwin_pos', previewwin_pos],


### PR DESCRIPTION
Allows mapping scope suffixes (e.g. 'function') to user-defined values.

This adds control over the display of scopes in the Tagbar window (e.g. displaying the `function` suffix as a nice character ⨍ or another string altogether).  If scope is not in `g:tagbar_scopestrs`, no replacement occurs.
```
let g:tagbar_scopestrs = {
\    'class': "\uf0e8",
\    'const': "\uf8ff",
\    'constant': "\uf8ff",
\    'function': "\uf794",
}```