### PR TITLE
Updated instance of a-sync call for tagbar originally implemented by @pangchol

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -2655,10 +2655,12 @@ function! s:AutoUpdate(fname, force, ...) abort
     " update the fileinfo
     let no_display = a:0 > 0 ? a:1 : 0
 
-    if !has('win32') && has('lambda')
+    if !has('win32') && has('lambda') && has('timers')
+        call tagbar#debug#log('Performing async call to AutoUpdate_CB')
         call timer_start(0, { -> AutoUpdate_CB(a:fname, a:force, no_display)})
     else
-        call AutoUpdate_CB(a:fname, a:force, a:0 < 0 ? a:1 : '0')
+        call tagbar#debug#log('Performing sync call to AutoUpdate_CB')
+        call AutoUpdate_CB(a:fname, a:force, no_display)
     endif
 endfunc
 

--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -2649,16 +2649,16 @@ endfunction
 " use timer_start to let tagbar async, this can increase vim open file performance and
 " fix windows blink when open some file.
 function! s:AutoUpdate(fname, force, ...) abort
+    let no_display = a:0 > 0 ? a:1 : 0
+
     if !has('win32') && has('lambda')
-        call timer_start(0, { -> AutoUpdate_CB(a:fname, a:force, a:0 > 0 ? a:1 : '0')})
+        call timer_start(0, { -> AutoUpdate_CB(a:fname, a:force, no_display)})
     else
         call AutoUpdate_CB(a:fname, a:force, a:0 < 0 ? a:1 : '0')
     endif
 endfunc
 
-function! AutoUpdate_CB(fname, force, ...) abort
-    let no_display = a:0 > 0 ? a:1 : 0
-    call tagbar#debug#log('AutoUpdate_CB(' . a:fname . ', ' . a:force . ', ' . a:0 . ')')
+function! AutoUpdate_CB(fname, force, no_display) abort
 
     " This file is being loaded due to a quickfix command like vimgrep, so
     " don't process it
@@ -2720,7 +2720,7 @@ function! AutoUpdate_CB(fname, force, ...) abort
         let updated = 1
     endif
 
-    if no_display
+    if a:no_display
         return
     endif
 

--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -2649,21 +2649,18 @@ endfunction
 " use timer_start to let tagbar async, this can increase vim open file performance and
 " fix windows blink when open some file.
 function! s:AutoUpdate(fname, force, ...) abort
-    let g:tagbar_update_fname = a:fname
-    let g:tagbar_update_force = a:force
-    let g:tagbar_no_display = a:0 > 0 ? a:1 : 0
-    if has('win32') " windows use timer_start will call bug
-        call AutoUpdate_CB(0)
+    if !has('win32') && has('lambda')
+        call timer_start(0, { -> AutoUpdate_CB(a:fname, a:force, a:0 < 0 ? a:1 : '0')})
     else
-        call timer_start(0, 'AutoUpdate_CB')
+        call AutoUpdate_CB(a:fname, a:force, a:0 < 0 ? a:1 : '0')
     endif
 endfunc
 
-function! AutoUpdate_CB(channel, ...) abort
-    " call tagbar#debug#log('AutoUpdate called [' . fname . ']')
-    let l:fname = g:tagbar_update_fname
-    let l:force = g:tagbar_update_force
-    let no_display = g:tagbar_no_display
+function! AutoUpdate_CB(fname, force, ...) abort
+    let l:fname = a:fname
+    let l:force = a:force
+    let no_display = a:0 < 0 ? a:1 : 0
+    call tagbar#debug#log('AutoUpdate_CB(' . a:fname . ', ' . a:force . ', ' . a:0 . ')')
 
     " This file is being loaded due to a quickfix command like vimgrep, so
     " don't process it

--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -2649,6 +2649,10 @@ endfunction
 " use timer_start to let tagbar async, this can increase vim open file performance and
 " fix windows blink when open some file.
 function! s:AutoUpdate(fname, force, ...) abort
+    call tagbar#debug#log('AutoUpdate called [' . a:fname . ']')
+
+    " Whether we want to skip actually displaying the tags in Tagbar and only
+    " update the fileinfo
     let no_display = a:0 > 0 ? a:1 : 0
 
     if !has('win32') && has('lambda')


### PR DESCRIPTION
Closes #532 

Update of PR #561 originally implemented by @panchol 

This uses a lambda callback to pass the parameters into the callback routine.

note: I kept the `has('win32')` bypass logic in there as per the comment left by @panchol. I don't have a win32 instance to attempt this on, so I can't speak to the comment about `timer_start()` not working correctly on windows.

Currently this is a partial implementation. It has not been heavily tested.