### PR TITLE
vim 7.4 compatibility for variable init

### DIFF
--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -116,6 +116,7 @@ function! s:setup_options() abort
 
     for [opt, val] in options
         call s:init_var(opt, val)
+        unlet val
     endfor
 endfunction
 call s:setup_options()


### PR DESCRIPTION
Closes #664 

Add `unlet val` to allow vim 7.4 compatibility for strict variable type