### PR TITLE
Hide signcolumn for tagbar window

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -991,6 +991,7 @@ function! s:InitWindow(autoclose) abort
     setlocal foldmethod&
     setlocal foldexpr&
 
+    silent! setlocal signcolumn=no
 
     let w:autoclose = a:autoclose
 


### PR DESCRIPTION
`signcolumn` doesn't seem to make sense for tagbar. Hiding it can help users save a little screen space.

**Before:**
![image](https://user-images.githubusercontent.com/6105425/94543662-ec625680-027c-11eb-9f1f-61a474fa9605.png)

**After:**
![image](https://user-images.githubusercontent.com/6105425/94543778-0f8d0600-027d-11eb-8356-578613f25415.png)
