### PR TITLE
Add typescript mappings for universal ctags

### DIFF
--- a/autoload/tagbar/types/uctags.vim
+++ b/autoload/tagbar/types/uctags.vim
@@ -957,6 +957,35 @@ function! tagbar#types#uctags#init(supported_types) abort
         \ {'short' : 'p', 'long' : 'procedures', 'fold' : 0, 'stl' : 1}
     \ ]
     let types.tcl = type_tcl
+    " TypeScript {{{1
+    let type_ts = tagbar#prototypes#typeinfo#new()
+    let type_ts.ctagstype = 'typescript'
+    let type_ts.kinds = [
+        \ {'short' : 'n', 'long' : 'namespaces',    'fold' : 0, 'stl' : 1},
+        \ {'short' : 'i', 'long' : 'interfaces',    'fold' : 0, 'stl' : 1},
+        \ {'short' : 'g', 'long' : 'enums',         'fold' : 0, 'stl' : 1},
+        \ {'short' : 'e', 'long' : 'enumerators',   'fold' : 0, 'stl' : 1},
+        \ {'short' : 'c', 'long' : 'classes',       'fold' : 0, 'stl' : 1},
+        \ {'short' : 'C', 'long' : 'constants',     'fold' : 0, 'stl' : 1},
+        \ {'short' : 'f', 'long' : 'functions',     'fold' : 0, 'stl' : 1},
+        \ {'short' : 'p', 'long' : 'properties',    'fold' : 0, 'stl' : 1},
+        \ {'short' : 'v', 'long' : 'variables',     'fold' : 0, 'stl' : 1},
+        \ {'short' : 'm', 'long' : 'methods',       'fold' : 0, 'stl' : 1},
+    \ ]
+    let type_ts.sro        = '.'
+    let type_ts.kind2scope = {
+        \ 'c' : 'class',
+        \ 'i' : 'interface',
+        \ 'g' : 'enum',
+        \ 'n' : 'namespace',
+    \ }
+    let type_ts.scope2kind = {
+        \ 'class'       : 'c',
+        \ 'interface'   : 'i',
+        \ 'enum'        : 'g',
+        \ 'namespace'   : 'n'
+    \ }
+    let types.typescript = type_ts
     " LaTeX {{{1
     let type_tex = tagbar#prototypes#typeinfo#new()
     let type_tex.ctagstype = 'tex'

--- a/autoload/tagbar/types/uctags.vim
+++ b/autoload/tagbar/types/uctags.vim
@@ -964,7 +964,7 @@ function! tagbar#types#uctags#init(supported_types) abort
         \ {'short' : 'n', 'long' : 'namespaces',    'fold' : 0, 'stl' : 1},
         \ {'short' : 'i', 'long' : 'interfaces',    'fold' : 0, 'stl' : 1},
         \ {'short' : 'g', 'long' : 'enums',         'fold' : 0, 'stl' : 1},
-        \ {'short' : 'e', 'long' : 'enumerators',   'fold' : 0, 'stl' : 1},
+        \ {'short' : 'e', 'long' : 'enumerations',  'fold' : 0, 'stl' : 1},
         \ {'short' : 'c', 'long' : 'classes',       'fold' : 0, 'stl' : 1},
         \ {'short' : 'C', 'long' : 'constants',     'fold' : 0, 'stl' : 1},
         \ {'short' : 'f', 'long' : 'functions',     'fold' : 0, 'stl' : 1},


### PR DESCRIPTION
Re: https://github.com/preservim/tagbar/issues/496

Adds basic Typescript mappings. I ended up skipping `tstags` support, as evidently it doesn't output scopes or enumerations in a compatible format:

```ts
// test.ts
enum Test {
  FOO,
}

class Bar {
  baz() {}
}
```
```sh
$ ctags -f - test.ts
Bar     test.ts      /^class Bar {$/;"       c
FOO     test.ts      /^  FOO,$/;"            e       enum:Test
Test    test.ts      /^enum Test {$/;"       g
baz     test.ts      /^  baz() {}$/;"        m       class:Bar

$ tstags -f - test.ts
Test     test.ts       /^enum Test {$/;"       e       line:1
Bar      test.ts       /^class Bar {$/;"       C       line:5
Bar#baz  test.ts       /^  baz() {}$/;"        m       line:6
```