### PR TITLE
Add protection for unknown kinds

### DIFF
--- a/autoload/tagbar/prototypes/typeinfo.vim
+++ b/autoload/tagbar/prototypes/typeinfo.vim
@@ -15,7 +15,8 @@ endfunction
 
 " s:getKind() {{{1
 function! s:getKind(kind) abort dict
-    let idx = self.kinddict[a:kind]
+    "let idx = self.kinddict[a:kind]
+    let idx = has_key(self.kinddict, a:kind) ? self.kinddict[a:kind] : -1
     return self.kinds[idx]
 endfunction
 

--- a/autoload/tagbar/sorting.vim
+++ b/autoload/tagbar/sorting.vim
@@ -21,6 +21,12 @@ endfunction
 function! s:compare_by_kind(tag1, tag2) abort
     let typeinfo = s:compare_typeinfo
 
+    if !has_key(typeinfo.kinddict, a:tag1.fields.kind)
+        return -1
+    endif
+    if !has_key(typeinfo.kinddict, a:tag2.fields.kind)
+        return 1
+    endif
     if typeinfo.kinddict[a:tag1.fields.kind] <#
      \ typeinfo.kinddict[a:tag2.fields.kind]
         return -1


### PR DESCRIPTION
Closes #672 #547

This is occurring because there are unknown `kinds` found when running ctags. This results in a dictionary lookup because the perl type isn't handling these other kinds. I suspect this may be a problem with any other supported language that does not have all kinds defined properly.

To fix this, we can perform a has_key() check prior to referencing the dictionary to ensure the dictionary has a valid key for the specified kind. This will prevent looking up a kind that we don't know about.

Note 1: Another way to fix this would be to add support in the perl type definitions for the `m` type and `a` type. This PR will address it globally so any unknown type will at least not cause failure.

Note 2: When an unknown kind is found, it can mess up the tag highlighting in the tagbar window. Not sure why this is occurring. I suspect it is something to do with the GetNearbyTag() routine, but I am not able to figure out how to handle this.