### PR TITLE
Scoped Highlighting

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1766,10 +1766,7 @@ function! s:create_pseudotag(name, parent, kind, typeinfo, fileinfo) abort
                     \ pseudotag.path . a:typeinfo.sro . pseudotag.name
     endif
     let pseudotag.depth = len(split(pseudotag.path, '\V' . escape(a:typeinfo.sro, '\')))
-    call tagbar#debug#log('pseudotag [' . pseudotag.strfmt() . '] depth set to ' . pseudotag.depth)
-
     let pseudotag.parent = a:parent
-
     let pseudotag.fileinfo = a:fileinfo
     let pseudotag.typeinfo = a:typeinfo
 
@@ -3025,7 +3022,7 @@ function! s:GetNearbyTag(request, forcecurrent, ...) abort
                 let tag = curtag
                 break
             endif
-            if a:request ==# 'highlight' && line == curline && curtag.depth <= 0
+            if a:request ==# 'highlight' && line == curline
                 let tag = curtag
                 break
             endif

--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1556,7 +1556,6 @@ function! s:ProcessTag(name, filename, pattern, fields, is_split, typeinfo, file
     endfor
     let pathlist = split(taginfo.path, '\V' . escape(a:typeinfo.sro, '\'))
     let taginfo.depth = len(pathlist)
-    call tagbar#debug#log('taginfo [' . taginfo.strfmt() . '] depth set to ' . taginfo.depth)
 
     " Needed for folding
     try

--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1981,8 +1981,6 @@ function! s:PrintKinds(typeinfo, fileinfo) abort
                     let curline                   = len(output) + offset
                     let tag.tline                 = curline
                     let a:fileinfo.tline[curline] = tag
-                    "let tag.depth                 = 1
-                    "call tagbar#debug#log('tag [' . tag.strfmt() . '] depth set to ' . tag.depth)
                 endfor
             endif
 

--- a/autoload/tagbar/prototypes/fileinfo.vim
+++ b/autoload/tagbar/prototypes/fileinfo.vim
@@ -12,6 +12,9 @@ function! tagbar#prototypes#fileinfo#new(fname, ftype, typeinfo) abort
     " Get file size
     let newobj.fsize = getfsize(a:fname)
 
+    " Get the number of lines in the file
+    let newobj.lnum = line('$')
+
     " The vim file type
     let newobj.ftype = a:ftype
 

--- a/autoload/tagbar/types/uctags.vim
+++ b/autoload/tagbar/types/uctags.vim
@@ -207,13 +207,11 @@ function! tagbar#types#uctags#init(supported_types) abort
     let type_c.kind2scope = {
         \ 'g' : 'enum',
         \ 's' : 'struct',
-        \ 'f' : 'functions',
         \ 'u' : 'union'
     \ }
     let type_c.scope2kind = {
         \ 'enum'   : 'g',
         \ 'struct' : 's',
-        \ 'functions' : 'f',
         \ 'union'  : 'u'
     \ }
     let types.c = type_c

--- a/autoload/tagbar/types/uctags.vim
+++ b/autoload/tagbar/types/uctags.vim
@@ -207,11 +207,13 @@ function! tagbar#types#uctags#init(supported_types) abort
     let type_c.kind2scope = {
         \ 'g' : 'enum',
         \ 's' : 'struct',
+        \ 'f' : 'functions',
         \ 'u' : 'union'
     \ }
     let type_c.scope2kind = {
         \ 'enum'   : 'g',
         \ 'struct' : 's',
+        \ 'functions' : 'f',
         \ 'union'  : 'u'
     \ }
     let types.c = type_c

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -1195,7 +1195,26 @@ kinds:      A list of the "language kinds" that should be listed in Tagbar,
                 "f:functions:1"
 <           would list all the function definitions in a file under the header
             "functions", fold them, and implicitly show them in the statusline
-            if tagbar#currenttag() is used.
+            if tagbar#currenttag() is used. The {stl} field is also used to
+            determine tag that are considered for scoped highlighting in the
+            tagbar window. By default, whenever the cursor is on a line
+            containing a known tag, then that tag will be highlighted in the
+            tagbar window. However if the cursor is not on a line containing a
+            tag, then only tags of a type that has {stl} set to 1 will be
+            highlighted. For example, in C the "macro" type has an {stl} value
+            of 0. So if there is a macro defined within the scope of a
+            function such as this:
+>
+                int function1(int arg) {
+                #define BUF_LENGTH    10
+                    char buffer[BUF_LENGTH + 1];
+                    snprintf(buffer, BUF_LENGTH, "some string");
+                }
+<
+            Then when the cursor is on the #define line, then that macro will
+            be highlighted in the tagbar window. However if the cursor was on
+            the snprintf() line, then the tag for function1() would be
+            highlighted.
 sro:        The scope resolution operator. For example, in C++ it is "::" and
             in Java it is ".". If in doubt run ctags as shown below and check
             the output.

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -348,6 +348,11 @@ FUNCTIONS                                                   *tagbar-functions*
     value. This also clears the internal flags to the file will be re-examined
     again.
 
+tagbar#printfileinfo()
+    This function is used in conjunction with |TagbarDebug| and will print all
+    the known tags into the tagbar debug logfile. This is useful for looking
+    at the internal tag information that tagbar tracks.
+
 ------------------------------------------------------------------------------
 KEY MAPPINGS                                                     *tagbar-keys*
 


### PR DESCRIPTION
Closes #376

Attempt to change the scoped highlighting of the tagbar window. This will now look only for 'stl' tag types when looking for the nearby tag when looking to highlight. It does however take into account if the cursor is on the same line as the tag and highlights it then as well.

Add debug function tagbar#printfileinfo() that can be used to print debug info to the tagbar debug file.

