### PR TITLE
Add g:tagbar_show_tag_count option

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1967,8 +1967,8 @@ function! s:PrintKinds(typeinfo, fileinfo) abort
             endif
 
             let padding = g:tagbar_show_visibility ? ' ' : ''
-            let tag_count = ' (' . len(curtags) . ')'
             if g:tagbar_show_tag_count
+                let tag_count = ' (' . len(curtags) . ')'
                 call add(output, foldmarker . padding . kind.long . tag_count)
             else
                 call add(output, foldmarker . padding . kind.long)

--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1967,7 +1967,12 @@ function! s:PrintKinds(typeinfo, fileinfo) abort
             endif
 
             let padding = g:tagbar_show_visibility ? ' ' : ''
-            call add(output, foldmarker . padding . kind.long)
+            let tag_count = ' (' . len(curtags) . ')'
+            if g:tagbar_show_tag_count
+                call add(output, foldmarker . padding . kind.long . tag_count)
+            else
+                call add(output, foldmarker . padding . kind.long)
+            endif
 
             let curline                   = len(output) + offset
             let kindtag.tline             = curline

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -719,6 +719,18 @@ Example:
 >
     let g:tagbar_show_tag_linenumbers = 1
 <
+                                                     *g:tagbar_show_tag_count*
+g:tagbar_show_tag_count~
+Default: 0
+
+This option allows showing the tag count next to the tag kind in the tagbar
+window. This will show up like this >
+   > functions (<tag-count>)
+<
+Example:
+>
+    let g:tagbar_show_tag_count = 1
+<
                                                      *g:tagbar_hide_nonpublic*
 g:tagbar_hide_nonpublic~
 Default: 0

--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -103,6 +103,7 @@ function! s:setup_options() abort
         \ ['show_balloon', 1],
         \ ['show_visibility', 1],
         \ ['show_linenumbers', 0],
+        \ ['show_tag_count', 0],
         \ ['show_tag_linenumbers', 0],
         \ ['singleclick', 0],
         \ ['sort', 1],


### PR DESCRIPTION
Closes #290

This option will show the tag kind count next to the kind label in the tagbar window. Note: this is limited to only the actual tag kinds. It does not list the count of members for a scoped value such as union or class.

Example:
```
" Press <F1>, ? for help

> macros (3)

> variables (1)
    global_union

> functions (6)
    function5(int i)
    funtion1(int i)
    funtion2(int i)
    funtion3(int i)
    funtion4(int i)
    main(int argc,char * argv[])
```