### PR TITLE
Help visibility

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1998,7 +1998,7 @@ function! s:PrintKinds(typeinfo, fileinfo) abort
     endfor
 
     let outstr = join(output, "\n")
-    if g:tagbar_compact && s:short_help
+    if g:tagbar_compact && !g:tagbar_help_visibility && s:short_help
         silent 0put =outstr
     else
         silent  put =outstr
@@ -2058,10 +2058,10 @@ endfunction
 
 " s:PrintHelp() {{{2
 function! s:PrintHelp() abort
-    if !g:tagbar_compact && s:short_help
+    if !g:tagbar_compact && !g:tagbar_help_visibility && s:short_help
         silent 0put ='\" Press ' . s:get_map_str('help') . ' for help'
         silent  put _
-    elseif !s:short_help
+    elseif g:tagbar_help_visibility || !s:short_help
         silent 0put ='\" Tagbar keybindings'
         silent  put ='\"'
         silent  put ='\" --------- General ---------'

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -631,7 +631,15 @@ Example:
 >
         let g:tagbar_compact = 1
 <
+                                                    *g:tagbar_help_visibility*
+g:tagbar_help_visibility~
+Default: 0
 
+Setting this option will cause the full help information to be displayed all
+the time in the tagbar window.
+>
+        let g:tagbar_help_visibility = 1
+<
                                                              *g:tagbar_indent*
 g:tagbar_indent~
 Default: 2

--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -97,6 +97,7 @@ function! s:setup_options() abort
         \ ['height', 10],
         \ ['indent', 2],
         \ ['left', 0],
+        \ ['help_visibility', 0],
         \ ['position', default_pos],
         \ ['previewwin_pos', previewwin_pos],
         \ ['scopestrs', {}],


### PR DESCRIPTION
Closes #410

Add `g:tagbar_help_visibility` option to always show the help dialog