### PR TITLE
shane: compact tag line# should be good enough if user set it

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -2202,7 +2202,7 @@ function! s:HighlightTag(openfolds, ...) abort
         " If printing the line number of the tag to the left, and the tag is
         " visible (I.E. parent isn't folded)
         if g:tagbar_show_tag_linenumbers == 2 && tagline == tag.tline
-            let pattern = '/^\%' . tagline . 'l\s*' . foldpat . '[-+# ]\[line [0-9]*\] \?\zs[^( ]\+\ze/'
+            let pattern = '/^\%' . tagline . 'l\s*' . foldpat . '[-+# ]\[[0-9]\+\] \?\zs[^( ]\+\ze/'
         else
             let pattern = '/^\%' . tagline . 'l\s*' . foldpat . '[-+# ]\?\zs[^( ]\+\ze/'
         endif

--- a/autoload/tagbar/prototypes/normaltag.vim
+++ b/autoload/tagbar/prototypes/normaltag.vim
@@ -37,9 +37,9 @@ function! s:strfmt() abort dict
     let prefix = self._getPrefix()
 
     if g:tagbar_show_tag_linenumbers == 1
-        let suffix .= ' [line ' . self.fields.line . ']'
+        let suffix .= ' [' . self.fields.line . ']'
     elseif g:tagbar_show_tag_linenumbers == 2
-        let prefix .= '[line ' . self.fields.line . '] '
+        let prefix .= '[' . self.fields.line . '] '
     endif
 
     return prefix . self.name . suffix

--- a/autoload/tagbar/prototypes/pseudotag.vim
+++ b/autoload/tagbar/prototypes/pseudotag.vim
@@ -23,9 +23,9 @@ function! s:strfmt() abort dict
     let prefix = self._getPrefix()
 
     if g:tagbar_show_tag_linenumbers == 1
-        let suffix .= ' [line ' . self.fields.line . ']'
+        let suffix .= ' [' . self.fields.line . ']'
     elseif g:tagbar_show_tag_linenumbers == 2
-        let prefix .= '[line ' . self.fields.line . '] '
+        let prefix .= '[' . self.fields.line . '] '
     endif
 
     return prefix . self.name . '*' . suffix

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -718,10 +718,10 @@ This option allows printing the tag line number next to the tag in the tagbar
 window. It can be set to the following values:
     0 - The line number will not be printed
     1 - The line number will be printed to the right of the tag >
-        Example:    function1(int i) [line 42]
+        Example:    function1(int i) [123]
 <
     2 - The line number will be printed to the left of the tag >
-        Example:    [line 42] function1(int i)
+        Example:    [123] function1(int i)
 <
 Example:
 >


### PR DESCRIPTION
pr for #684
short/compact '[123]' should be good enough.. if user opened set 'g:tagbar_show_tag_linenumbers', he/she should be awared that is a linenum already.
// the pattern [0-9]* for hl was not accurate, line# should be always existed or there was no that tag existed.
@raven42  pls review, and merge if ok.