### PR TITLE
Add g:tagbar_scroll_offset configuration

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -947,8 +947,8 @@ function! s:InitWindow(autoclose) abort
     setlocal nomodifiable
     setlocal textwidth=0
 
-    if g:tagbar_scroll_offset > 0
-        execute 'setlocal scrolloff=' . g:tagbar_scroll_offset
+    if g:tagbar_scrolloff > 0
+        execute 'setlocal scrolloff=' . g:tagbar_scrolloff
     endif
 
     if g:tagbar_show_balloon == 1 && has('balloon_eval')

--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -947,6 +947,10 @@ function! s:InitWindow(autoclose) abort
     setlocal nomodifiable
     setlocal textwidth=0
 
+    if g:tagbar_scroll_offset > 0
+        execute 'setlocal scrolloff=' . g:tagbar_scroll_offset
+    endif
+
     if g:tagbar_show_balloon == 1 && has('balloon_eval')
         setlocal balloonexpr=TagbarBalloonExpr()
         set ballooneval

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -1021,6 +1021,21 @@ Example:
 >
        let g:tagbar_wrap = 1
 <
+                                                      *g:tagbar_scroll_offset*
+g:tagbar_scroll_offset~
+Default: 0
+
+If set to non-zero, the tagbar window initialization will set the |scrolloff|
+value local to the tagbar window to the specified value. This is used to
+position the current tag in the tagbar window. See the help for |scrolloff|
+for more details. If set to a very high value (greater than the height of the
+tagbar window), then the current tag should always stay in the center of the
+tagbar window.
+
+Example:
+>
+        let g:tagbar_scroll_offset = 10
+<
 
 ------------------------------------------------------------------------------
 HIGHLIGHT COLOURS                                           *tagbar-highlight*

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -1023,14 +1023,14 @@ Example:
 <
                                                       *g:tagbar_scrolloff*
 g:tagbar_scrolloff~
-Default: 0
+Default: |scrolloff|
 
-If set to non-zero, the tagbar window initialization will set the |scrolloff|
+If set, the tagbar window initialization will set the |scrolloff|
 value local to the tagbar window to the specified value. This is used to
 position the current tag in the tagbar window. See the help for |scrolloff|
 for more details. If set to a very high value (greater than the height of the
 tagbar window), then the current tag should always stay in the center of the
-tagbar window.
+tagbar window. This defaults to the global |scrolloff| value.
 
 Example:
 >

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -1021,8 +1021,8 @@ Example:
 >
        let g:tagbar_wrap = 1
 <
-                                                      *g:tagbar_scroll_offset*
-g:tagbar_scroll_offset~
+                                                      *g:tagbar_scrolloff*
+g:tagbar_scrolloff~
 Default: 0
 
 If set to non-zero, the tagbar window initialization will set the |scrolloff|
@@ -1034,7 +1034,7 @@ tagbar window.
 
 Example:
 >
-        let g:tagbar_scroll_offset = 10
+        let g:tagbar_scrolloff = 10
 <
 
 ------------------------------------------------------------------------------

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -1023,14 +1023,14 @@ Example:
 <
                                                       *g:tagbar_scrolloff*
 g:tagbar_scrolloff~
-Default: |scrolloff|
+Default: 0
 
-If set, the tagbar window initialization will set the |scrolloff|
+If set to non-zero, the tagbar window initialization will set the |scrolloff|
 value local to the tagbar window to the specified value. This is used to
 position the current tag in the tagbar window. See the help for |scrolloff|
 for more details. If set to a very high value (greater than the height of the
 tagbar window), then the current tag should always stay in the center of the
-tagbar window. This defaults to the global |scrolloff| value.
+tagbar window.
 
 Example:
 >

--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -101,7 +101,7 @@ function! s:setup_options() abort
         \ ['position', default_pos],
         \ ['previewwin_pos', previewwin_pos],
         \ ['scopestrs', {}],
-        \ ['scroll_offset', 0],
+        \ ['scrolloff', 0],
         \ ['show_balloon', 1],
         \ ['show_visibility', 1],
         \ ['show_linenumbers', 0],

--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -83,6 +83,7 @@ function! s:setup_options() abort
             let default_pos = 'botright vertical'
         endif
     endif
+    let default_scrolloff = &scrolloff
     let options = [
         \ ['autoclose', 0],
         \ ['autofocus', 0],
@@ -101,7 +102,7 @@ function! s:setup_options() abort
         \ ['position', default_pos],
         \ ['previewwin_pos', previewwin_pos],
         \ ['scopestrs', {}],
-        \ ['scrolloff', 0],
+        \ ['scrolloff', default_scrolloff],
         \ ['show_balloon', 1],
         \ ['show_visibility', 1],
         \ ['show_linenumbers', 0],

--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -101,6 +101,7 @@ function! s:setup_options() abort
         \ ['position', default_pos],
         \ ['previewwin_pos', previewwin_pos],
         \ ['scopestrs', {}],
+        \ ['scroll_offset', 0],
         \ ['show_balloon', 1],
         \ ['show_visibility', 1],
         \ ['show_linenumbers', 0],

--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -83,7 +83,6 @@ function! s:setup_options() abort
             let default_pos = 'botright vertical'
         endif
     endif
-    let default_scrolloff = &scrolloff
     let options = [
         \ ['autoclose', 0],
         \ ['autofocus', 0],
@@ -102,7 +101,7 @@ function! s:setup_options() abort
         \ ['position', default_pos],
         \ ['previewwin_pos', previewwin_pos],
         \ ['scopestrs', {}],
-        \ ['scrolloff', default_scrolloff],
+        \ ['scrolloff', 0],
         \ ['show_balloon', 1],
         \ ['show_visibility', 1],
         \ ['show_linenumbers', 0],


### PR DESCRIPTION
Closes #564

Add option for `g:tagbar_scroll_offset` to issue a `setlocal scrolloff=#` during tagbar window init