### PR TITLE
Fix issue with tagbar changing the global scrolloff value.

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1912,7 +1912,7 @@ function! s:RenderContent(...) abort
         normal! zt
         call cursor(saveline, savecol)
 
-        execute 'setlocal scrolloff=' . scrolloff_save
+        let &l:scrolloff = scrolloff_save
     else
         " Make sure as much of the Tagbar content as possible is shown in the
         " window by jumping to the top after drawing

--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1906,13 +1906,13 @@ function! s:RenderContent(...) abort
     if !empty(tagbar#state#get_current_file(0)) &&
      \ fileinfo.fpath ==# tagbar#state#get_current_file(0).fpath
         let scrolloff_save = &scrolloff
-        set scrolloff=0
+        setlocal scrolloff=0
 
         call cursor(topline, 1)
         normal! zt
         call cursor(saveline, savecol)
 
-        let &scrolloff = scrolloff_save
+        execute 'setlocal scrolloff=' . scrolloff_save
     else
         " Make sure as much of the Tagbar content as possible is shown in the
         " window by jumping to the top after drawing


### PR DESCRIPTION
Closes #693

Tagbar is overwriting the global scrolloff value which can affect other windows. Change the behavior so it does a setlocal instead when needed so this only impacts the tagbar window