### PR TITLE
Add g:tagbar_jump_offset configuration

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -2279,6 +2279,21 @@ function! s:JumpToTag(stay_in_tagbar) abort
     " Center the tag in the window and jump to the correct column if
     " available, otherwise try to find it in the line
     normal! z.
+
+    " If configured, adjust the jump_offset and center the window on that
+    " line. Then fall-through adjust the cursor() position below that
+    if g:tagbar_jump_offset != 0 && g:tagbar_jump_offset < curline
+        if g:tagbar_jump_offset > winheight(0) / 2
+            let jump_offset = winheight(0) / 2
+        elseif g:tagbar_jump_offset < -winheight(0) / 2
+            let jump_offset = -winheight(0) / 2
+        else
+            let jump_offset = g:tagbar_jump_offset
+        endif
+        execute curline+jump_offset
+        normal! z.
+    endif
+
     if taginfo.fields.column > 0
         call cursor(taginfo.fields.line, taginfo.fields.column)
     else

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -1040,6 +1040,32 @@ Example:
 >
         let g:tagbar_scrolloff = 10
 <
+                                                        *g:tagbar_jump_offset*
+g:tagbar_jump_offset~
+Default: 0
+
+This value can be used to control the jump offset positioning. When jumping to
+a tag from the tagbar window, the tag will appear |g:tagbar_jump_offset| lines
+above or below the center of the window. For example, if set to 10 and you
+jump to a tag, the tag will appear 10 lines above the center of the window.
+This can also be set to a negative value if you want the tag jump location to
+be below the center of the window.
+
+If set to greater than |winheight|() then the tag will always appear at the
+top of the screen. If set to less than -|winheight|(), then the tag will
+always appear at the bottom of the screen.
+
+Examples:
+>
+        " Set the tag jump location to appear at the top
+        let g:tagbar_jump_offset = 999
+
+        " Set the tag jump locaiton to appear at the bottom
+        let g:tagbar_jump_offset = -999
+
+        " Set the tag jump location to appear 25% from the top
+        let g:tagbar_jump_offset = winheight(0) / 4
+<
 
 ------------------------------------------------------------------------------
 HIGHLIGHT COLOURS                                           *tagbar-highlight*

--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -96,6 +96,7 @@ function! s:setup_options() abort
         \ ['hide_nonpublic', 0],
         \ ['height', 10],
         \ ['indent', 2],
+        \ ['jump_offset', 0],
         \ ['left', 0],
         \ ['help_visibility', 0],
         \ ['position', default_pos],


### PR DESCRIPTION
Closes #504

Add a new `g:tagbar_jump_offset` value which will control the tag jump location relative to the center of the screen.