### PR TITLE
shane: tag line# at right may mess with type syn hl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/doc/tags
+tags

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -1101,6 +1101,9 @@ TagbarScope
 TagbarType
     The type of a tag or scope if available.
 
+TagbarTagLineN
+    The source line number displayed to the right of each tag entry.
+
 TagbarSignature
     Function signatures.
 

--- a/syntax/tagbar.vim
+++ b/syntax/tagbar.vim
@@ -36,7 +36,8 @@ syntax match TagbarHelpKey   '" \zs.*\ze:' contained
 syntax match TagbarHelpTitle '" \zs-\+ \w\+ -\+' contained
 
 syntax match TagbarNestedKind '^\s\+\[[^]]\+\]$'
-syntax match TagbarType       ' : \zs.*'
+syntax match TagbarType       ' : \zs.*' contains=TagbarTagLineN
+syntax match TagbarTagLineN   '\s\+\[[0-9]\+\]\(\s\+\|$\)'
 syntax match TagbarSignature  '(.*)'
 syntax match TagbarPseudoID   '\*\ze :'
 
@@ -47,6 +48,7 @@ highlight default link TagbarKind       Identifier
 highlight default link TagbarNestedKind TagbarKind
 highlight default link TagbarScope      Title
 highlight default link TagbarType       Type
+highlight default link TagbarTagLineN   Comment
 highlight default link TagbarSignature  SpecialKey
 highlight default link TagbarPseudoID   NonText
 highlight default link TagbarFoldIcon   Statement


### PR DESCRIPTION
refine for #687
there was perhaps a bit flaw, if set tag line# on and line# showed at right, looks it took same 'syn highlight' like 'parameter' or 'return type' etc such strings of ori func/tag; this is regardless compact or not, should be not an issue, but just maybe would not look very nice...
![image](https://user-images.githubusercontent.com/13550529/97898671-25598380-1d73-11eb-9822-74e79521d7e1.png)
// try to fix it...