### PR TITLE
Add `tagbar#IsOpen()` helper routine

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -3947,5 +3947,17 @@ function! tagbar#printfileinfo() abort
     echo 'Tagbar fileinfo printed to debug logfile'
 endfunction
 
+" tagbar#IsOpen() {{{2
+function! tagbar#IsOpen() abort
+    let tagbarwinnr = bufwinnr('__Tagbar__')
+    if tagbarwinnr != -1
+        " Window open
+        return 1
+    else
+        " Window not open
+        return 0
+    endif
+endfunction
+
 " Modeline {{{1
 " vim: ts=8 sw=4 sts=4 et foldenable foldmethod=marker foldcolumn=1

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -351,10 +351,14 @@ FUNCTIONS                                                   *tagbar-functions*
     value. This also clears the internal flags to the file will be re-examined
     again.
 
-tagbar#printfileinfo()
+*tagbar#printfileinfo()*
     This function is used in conjunction with |TagbarDebug| and will print all
     the known tags into the tagbar debug logfile. This is useful for looking
     at the internal tag information that tagbar tracks.
+
+*tagbar#IsOpen()*
+    This function will return 1 if the tagbar window is open, else it will
+    return 0.
 
 ------------------------------------------------------------------------------
 KEY MAPPINGS                                                     *tagbar-keys*


### PR DESCRIPTION
Closes #717

Add a `tagbar#IsOpen()` helper routine to check if the tagbar window is open or not.