### PR TITLE
Add support for kotlin type

### DIFF
--- a/autoload/tagbar/types/uctags.vim
+++ b/autoload/tagbar/types/uctags.vim
@@ -584,6 +584,31 @@ function! tagbar#types#uctags#init(supported_types) abort
         \ 'function' : 'f',
     \ }
     let types.javascript = type_javascript
+
+    " Kotlin {{{1
+    let type_kotlin = tagbar#prototypes#typeinfo#new()
+    let type_kotlin.ctagstype = 'kotlin'
+    let type_kotlin.kinds = [
+        \ {'short': 'p', 'long': 'packages',    'fold':0, 'stl':0},
+        \ {'short': 'c', 'long': 'classes',     'fold':0, 'stl':1},
+        \ {'short': 'o', 'long': 'objects',     'fold':0, 'stl':0},
+        \ {'short': 'i', 'long': 'interfaces',  'fold':0, 'stl':0},
+        \ {'short': 'T', 'long': 'typealiases', 'fold':0, 'stl':0},
+        \ {'short': 'm', 'long': 'methods',     'fold':0, 'stl':1},
+        \ {'short': 'C', 'long': 'constants',   'fold':0, 'stl':0},
+        \ {'short': 'v', 'long': 'variables',   'fold':0, 'stl':0},
+    \ ]
+    let type_kotlin.sro         = '.'
+    " Note: the current universal ctags version does not have proper
+    " definition for the scope of the tags. So for now we can't add the
+    " kind2scope / scope2kind for anything until ctags supports the correct
+    " scope info
+    let type_kotlin.kind2scope  = {
+    \ }
+    let type_kotlin.scope2kind  = {
+    \ }
+    let types.kotlin = type_kotlin
+
     " Lisp {{{1
     let type_lisp = tagbar#prototypes#typeinfo#new()
     let type_lisp.ctagstype = 'lisp'


### PR DESCRIPTION
Closes #632

Support for kotlin type was recently added into universal ctags
(https://github.com/universal-ctags/ctags/pull/2769)

Currently there is no scope information in the ctags definition. So the
`scope2kind` and `kind2scope` settings are not functional. If support is
added, then these definitions can be updated to include that info.

Note: these kind definitions are based on the output from `ctags
--list-kinds=kotlin` which is slightly different than the definitions
provided in #632. So this may not be fully compatible with the custom
ctags configuration from that issue. The default definition for
univercal ctags should be used instead.