### PR TITLE
Check for tilde in cpp destructor

### DIFF
--- a/autoload/tagbar/prototypes/normaltag.vim
+++ b/autoload/tagbar/prototypes/normaltag.vim
@@ -152,7 +152,8 @@ function! s:getDataType() abort dict
         endif
 
         let line = getbufline(bufnr, self.fields.line)[0]
-        let data_type = substitute(line, '\s*' . self.name . '.*', '', '')
+        let tmp_name = substitute(self.name, "\\~", "", "g")
+        let data_type = substitute(line, '\s*' . tmp_name . '.*', '', '')
 
         " Strip off the path if we have one along with any spaces prior to the
         " path

--- a/autoload/tagbar/prototypes/normaltag.vim
+++ b/autoload/tagbar/prototypes/normaltag.vim
@@ -152,7 +152,7 @@ function! s:getDataType() abort dict
         endif
 
         let line = getbufline(bufnr, self.fields.line)[0]
-        let tmp_name = substitute(self.name, "\\~", "", "g")
+        let tmp_name = substitute(self.name, "\\~", '', 'g')
         let data_type = substitute(line, '\s*' . tmp_name . '.*', '', '')
 
         " Strip off the path if we have one along with any spaces prior to the


### PR DESCRIPTION
Closes #729

Use temporary variable to store name so we can escape out the tilde `~`
character from the tag name so it does not interfere with the string
parsing