### PR TITLE
Fix the problem that the data type was unexpectedly displayed in the C++ destructor's tag.

### DIFF
--- a/autoload/tagbar/prototypes/normaltag.vim
+++ b/autoload/tagbar/prototypes/normaltag.vim
@@ -152,7 +152,7 @@ function! s:getDataType() abort dict
         endif
 
         let line = getbufline(bufnr, self.fields.line)[0]
-        if (self.name =~ '^\s*\~')
+        if (self.name =~# '^\s*\~')
             let data_type = ''
         else
             let data_type = substitute(line, '\s*' . self.name . '.*', '', '')

--- a/autoload/tagbar/prototypes/normaltag.vim
+++ b/autoload/tagbar/prototypes/normaltag.vim
@@ -152,8 +152,11 @@ function! s:getDataType() abort dict
         endif
 
         let line = getbufline(bufnr, self.fields.line)[0]
-        let tmp_name = substitute(self.name, "\\~", '', 'g')
-        let data_type = substitute(line, '\s*' . tmp_name . '.*', '', '')
+        if (self.name =~ '^\s*\~')
+            let data_type = ''
+        else
+            let data_type = substitute(line, '\s*' . self.name . '.*', '', '')
+        endif
 
         " Strip off the path if we have one along with any spaces prior to the
         " path


### PR DESCRIPTION
Make some corrections to  #732 
Same as constructor, destructor has no data type
Solve the problem shown in the figure below

![擷取](https://user-images.githubusercontent.com/24770129/103791184-1a75e480-507d-11eb-9f3c-db4d66b0d5c1.PNG)
