### PR TITLE
Improve tag highlighting and signature matching

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -2273,10 +2273,11 @@ function! s:HighlightTag(openfolds, ...) abort
 
         " If printing the line number of the tag to the left, and the tag is
         " visible (I.E. parent isn't folded)
+        let identifier = '\zs\V' . tag.name . '\m\ze'
         if g:tagbar_show_tag_linenumbers == 2 && tagline == tag.tline
-            let pattern = '/^\%' . tagline . 'l\s*' . foldpat . '[-+# ]\[[0-9]\+\] \?\zs[^( ]\+\ze/'
+            let pattern = '/^\%' . tagline . 'l\s*' . foldpat . '[-+# ]\[[0-9]\+\] \?' . identifier . '/'
         else
-            let pattern = '/^\%' . tagline . 'l\s*' . foldpat . '[-+# ]\?\zs[^( ]\+\ze/'
+            let pattern = '/^\%' . tagline . 'l\s*' . foldpat . '[-+# ]\?' . identifier . '/'
         endif
         call tagbar#debug#log("Highlight pattern: '" . pattern . "'")
         if hlexists('TagbarHighlight') " Safeguard in case syntax highlighting is disabled

--- a/syntax/tagbar.vim
+++ b/syntax/tagbar.vim
@@ -38,7 +38,7 @@ syntax match TagbarHelpTitle '" \zs-\+ \w\+ -\+' contained
 syntax match TagbarNestedKind '^\s\+\[[^]]\+\]$'
 syntax match TagbarType       ' : \zs.*' contains=TagbarTagLineN
 syntax match TagbarTagLineN   '\s\+\[[0-9]\+\]\(\s\+\|$\)'
-syntax match TagbarSignature  '(.*)'
+syntax match TagbarSignature  '\(\<operator *( *) *\)\?\zs(.*)\ze'
 syntax match TagbarPseudoID   '\*\ze :'
 
 highlight default link TagbarHelp       Comment


### PR DESCRIPTION
1. Correctly highlight tags that contain spaces.
2. Match function signature on special case: operator()(...).

e.g.
![sig](https://user-images.githubusercontent.com/24770129/104118502-a1200f80-5364-11eb-9812-0ba2722d425b.PNG)
![tag](https://user-images.githubusercontent.com/24770129/104118482-77ff7f00-5364-11eb-8a09-4db3155d4d8b.PNG)
