### PR TITLE
fixed: CJK characters decoding error problem

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -3051,7 +3051,7 @@ function! s:run_system(cmd, version) abort
         exec pyx . '__argv = {"args":vim.eval("a:cmd"), "shell":True}'
         exec pyx . '__argv["stdout"] = subprocess.PIPE'
         exec pyx . '__argv["stderr"] = subprocess.STDOUT'
-        exec pyx . '__argv["errors"] = "ignore" '
+        exec pyx . '__argv["errors"] = "ignore"'
         exec pyx . '__pp = subprocess.Popen(**__argv, universal_newlines=True)'
         exec pyx . '__return_text = __pp.stdout.read()'
         exec pyx . '__pp.stdout.close()'

--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -3051,6 +3051,7 @@ function! s:run_system(cmd, version) abort
         exec pyx . '__argv = {"args":vim.eval("a:cmd"), "shell":True}'
         exec pyx . '__argv["stdout"] = subprocess.PIPE'
         exec pyx . '__argv["stderr"] = subprocess.STDOUT'
+        exec pyx . '__argv["errors"] = "ignore" '
         exec pyx . '__pp = subprocess.Popen(**__argv, universal_newlines=True)'
         exec pyx . '__return_text = __pp.stdout.read()'
         exec pyx . '__pp.stdout.close()'


### PR DESCRIPTION
[PR 733](https://github.com/preservim/tagbar/pull/733) changed popen output format from binary to text but forgot to initialize `errors` to `ignore`, which may crash when there are unicode decoding errors:

![图片](https://user-images.githubusercontent.com/3035071/105606554-0a783780-5dd5-11eb-8884-1f6c7b9988eb.png)

and:

![图片](https://user-images.githubusercontent.com/3035071/105606555-119f4580-5dd5-11eb-8610-89da2aa387dd.png)

When filenames contain strange CJK characters, python's `decode` may fail. A `errors = "ignore"` can simply fix this.