### PR TITLE
read ctags output using the utf8 encoding (see issue: #748)

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -3052,7 +3052,7 @@ function! s:run_system(cmd, version) abort
         exec pyx . '__argv["stdout"] = subprocess.PIPE'
         exec pyx . '__argv["stderr"] = subprocess.STDOUT'
         exec pyx . '__argv["errors"] = "ignore"'
-        exec pyx . '__pp = subprocess.Popen(**__argv, universal_newlines=True)'
+        exec pyx . '__pp = subprocess.Popen(**__argv, universal_newlines=True, encoding="utf8")'
         exec pyx . '__return_text = __pp.stdout.read()'
         exec pyx . '__pp.stdout.close()'
         exec pyx . '__return_code = __pp.wait()'


### PR DESCRIPTION
The ctags default output encoding is utf8. This pull request propose to default to utf8 when reading the ctags output. Otherwise for some files (e.g. _vimrc in my case) ctags fails to parse the output.