### PR TITLE
Add Terraform (HCL) (*.tf) support

### DIFF
--- a/autoload/tagbar/types/uctags.vim
+++ b/autoload/tagbar/types/uctags.vim
@@ -1053,6 +1053,25 @@ function! tagbar#types#uctags#init(supported_types) abort
         \ {'short' : 'p', 'long' : 'procedures', 'fold' : 0, 'stl' : 1}
     \ ]
     let types.tcl = type_tcl
+    " Terraform (HCL) {{{1
+    let type_tf = tagbar#prototypes#typeinfo#new()
+    let type_tf.ctagstype = 'tf'
+    let type_tf.kinds = [
+      \ 'r:Resource',
+      \ 'R:Resource',
+      \ 'd:Data',
+      \ 'D:Data',
+      \ 'v:Variable',
+      \ 'V:Variable',
+      \ 'p:Provider',
+      \ 'P:Provider',
+      \ 'm:Module',
+      \ 'M:Module',
+      \ 'o:Output',
+      \ 'O:Output',
+      \ 'f:TFVar',
+      \ 'F:TFVar'
+    \ ]         
     " TypeScript {{{1
     let type_ts = tagbar#prototypes#typeinfo#new()
     let type_ts.ctagstype = 'typescript'

--- a/autoload/tagbar/types/uctags.vim
+++ b/autoload/tagbar/types/uctags.vim
@@ -1055,22 +1055,15 @@ function! tagbar#types#uctags#init(supported_types) abort
     let types.tcl = type_tcl
     " Terraform (HCL) {{{1
     let type_tf = tagbar#prototypes#typeinfo#new()
-    let type_tf.ctagstype = 'tf'
+    let type_tf.ctagstype = 'terraform'
     let type_tf.kinds = [
-      \ 'r:Resource',
-      \ 'R:Resource',
-      \ 'd:Data',
-      \ 'D:Data',
-      \ 'v:Variable',
-      \ 'V:Variable',
-      \ 'p:Provider',
-      \ 'P:Provider',
-      \ 'm:Module',
-      \ 'M:Module',
-      \ 'o:Output',
-      \ 'O:Output',
-      \ 'f:TFVar',
-      \ 'F:TFVar'
+      \ {'short' : 'r', 'long' : 'resources', 'fold' : 0, 'stl' : 0},
+      \ {'short' : 'd', 'long' : 'data', 'fold' : 0, 'stl' : 0},
+      \ {'short' : 'v', 'long' : 'variables', 'fold' : 0, 'stl' : 0},
+      \ {'short' : 'p', 'long' : 'providers', 'fold' : 0, 'stl' : 0},
+      \ {'short' : 'm', 'long' : 'modules', 'fold' : 0, 'stl' : 0},
+      \ {'short' : 'o', 'long' : 'output', 'fold' : 0, 'stl' : 0},
+      \ {'short' : 'l', 'long' : 'locals', 'fold' : 0, 'stl' : 0},
     \ ]         
     " TypeScript {{{1
     let type_ts = tagbar#prototypes#typeinfo#new()


### PR DESCRIPTION
Best-guess at implementing this; please advise if changes required.

This cannot be merged until after https://github.com/universal-ctags/ctags/pull/2952 is merged, since it required Terraform support in ctags itself.

Related discussion: https://github.com/preservim/tagbar/issues/757