### PR TITLE
Update contributor callouts and add sponsor links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: [alerque]
+custom: ['https://paypal.me/alerque']

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
 github: [alerque]
-custom: ['https://paypal.me/alerque']
+custom: ['https://paypal.me/alerque', 'https://paypal.me/dhegland42']

--- a/README.md
+++ b/README.md
@@ -96,5 +96,5 @@ Tagbar is distributed under the terms of the *Vim license*, see the included [LI
 
 Tagbar was originally written by [Jan Larres](https://github.com/majutsushi).
 It is actively maintained by [Caleb Maclennan](https://github.com/alerque).
-At least [45 others have contributed](https://github.com/preservim/tagbar/graphs/contributors) features and bug fixes over the years.
+At least [75 others have contributed](https://github.com/preservim/tagbar/graphs/contributors) features and bug fixes over the years.
 Please document [issues](https://github.com/preservim/tagbar/issues) or submit [pull requests](https://github.com/preservim/tagbar/issues) on Github.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,6 @@ Tagbar is distributed under the terms of the *Vim license*, see the included [LI
 ## Contributors
 
 Tagbar was originally written by [Jan Larres](https://github.com/majutsushi).
-It is actively maintained by [Caleb Maclennan](https://github.com/alerque).
+It is actively maintained by [Caleb Maclennan](https://github.com/alerque) and [David Hegland](https://github.com/raven42).
 At least [75 others have contributed](https://github.com/preservim/tagbar/graphs/contributors) features and bug fixes over the years.
 Please document [issues](https://github.com/preservim/tagbar/issues) or submit [pull requests](https://github.com/preservim/tagbar/issues) on Github.


### PR DESCRIPTION
# A new maintainer

**TL;DR: Please welcome @raven42 as one of the new overlords for this plugin!**

Last August when I [proposed migrating this repo to the PreserVIM](https://github.com/preservim/tagbar/issues/651) one of the primary objectives (see point 2 in proposal) was to be able to give good contributors more ownership in the maintenance process:

> 2. I would like to be able to invite people that have made substantial contributions as collaborators at least with limited permissions. GitHub has nice granular tools for this so that at least others could help some with issue triage directly and even merge PRs (with for example a requirement of one review approval). When people are contributing anyway and doing so in clearly positive ways giving them a little control usually helps motivate more of the same. Also it would help keep the whole project responsive so that it doesn't get held up during periods where I am not as available. There have been weeks and months already where things waited on me to have time for open source work.

Shortly after migrating the repository I invited two people (raven42 and wsdjeg) to join the @tagbar-contributors team. The way I setup the team and repository permissions those contributors are enabled to to make a lot of things happen, but with some constraints. They are able to triage issues and review PRs. They can merge PRs that have been approved, which means they can enable 3rd party contributions all the way to production without my help. What they can't do is push changes through directly themselves without my intervention, at least one other team member would need to sign off on a PR.

Since then I've observed @raven42 taking on a substantial role in the project. Besides the quality contributions they were already making, they started jumping in solving other people's issues, answering questions, and even fulfilling feature requests. My observation of both their code and the personal interaction in issues lead me to believe they are at least as invested and beneficial to the project as I am. Just a few minutes ago invited them to join the repository with admin privileges. This is a step up from the contributors team in that they can override the required PR checks and review process if necessary (for example if the CI results break) and merge their own PRs if no other team members are available to review them.

I don't plan on changing my own level of activity right now; I'll still be around to helping with issue triage, facilitating 3rd party contributions, and the occasionally contributing myself as I have time or interest. What it will mean in that I won't worry about checking in on things while traveling because I know that I won't be holding up the show if it's not a good time for me. This is just the way open source contribution usually works and I'm quite aware my availability (and lack thereof) comes in waves.

I've also added a callout to the readme noting this change. ~~@raven42 please feel free to amend that commit with however you want to be identified there.~~

# On the lookout for contributors

The contributors team could always use more hands and I'll be on the lookout of any other contributors with either ongoing quality code contributions or activity helping resolve issues.

# Sponsorships

Lastly I'm enabling the GitHub sponsorships button as a possible way to tip/thank those who have made this possible. Honestly my hopes for this are low (having enabled if for some much higher profile projects where my contributions are much more substantial and only seeing a trickle of support, but it's a nice encouragement none the less). Ideally I would like to see this include @majutsushi for the lions share of the work putting this plugin into circulation and @raven42 for their development role over the last year. I see neither of you have GitHub [Sponsors](https://github.com/sponsors) enabled for your accounts. I realize this requires setting up banking information with GitHub which may be not possible or undesirable and the system is not even allowed in all countries, but if you are interested in this being enabled for you please set it up. Also they allow links to other systems, if one of them suits you better lets add whatever linkage you prefer:


```yaml
# These are supported funding model platforms

github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
patreon: # Replace with a single Patreon username
open_collective: # Replace with a single Open Collective username
ko_fi: # Replace with a single Ko-fi username
tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
liberapay: # Replace with a single Liberapay username
issuehunt: # Replace with a single IssueHunt username
otechie: # Replace with a single Otechie username
custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
```
