### PR TITLE
Remove open buffer from known files on bdelete or bwipe

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -3462,12 +3462,12 @@ function! s:HandleBufDelete(bufname, bufnr) abort
         return
     endif
 
+    call s:known_files.rm(fnamemodify(a:bufname, ':p'))
+
     let tagbarwinnr = bufwinnr(s:TagbarBufName())
     if tagbarwinnr == -1 || a:bufname =~# '__Tagbar__.*'
         return
     endif
-
-    call s:known_files.rm(fnamemodify(a:bufname, ':p'))
 
     if !s:HasOpenFileWindows()
         if tabpagenr('$') == 1 && exists('t:tagbar_buf_name')


### PR DESCRIPTION
Closes #750

On `:bdelete` or `:bwipe` of a file, remove the file from the known file
listing even if the tagbar window is not open. Previously was only
removing the file if the tagbar window was open.