### PR TITLE
Fix for #750 to cleanup files once tagbar window closed

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -582,8 +582,6 @@ function! s:CreateAutocommands() abort
                 autocmd CursorHoldI * call
                         \ s:AutoUpdate(fnamemodify(expand('<afile>'), ':p'), 0)
             endif
-            autocmd BufDelete,BufWipeout *
-                        \ nested call s:HandleBufDelete(expand('<afile>'), expand('<abuf>'))
 
             " Suspend Tagbar while grep commands are running, since we don't want
             " to process files that only get loaded temporarily to search them
@@ -593,6 +591,15 @@ function! s:CreateAutocommands() abort
                         \ endif
 
             autocmd VimEnter * call s:CorrectFocusOnStartup()
+        endif
+    augroup END
+
+    " Separate these autocmds out from the others as we want to always perform
+    " these actions even if the tagbar window closes.
+    augroup TagbarCleanupAutoCmds
+        if !g:tagbar_no_autocmds
+            autocmd BufDelete,BufWipeout *
+                        \ nested call s:HandleBufDelete(expand('<afile>'), expand('<abuf>'))
         endif
     augroup END
 


### PR DESCRIPTION
Fixes #750

Once the tagbar window is opened and a file is registered, that file
stays in memory even if the tagbar window is closed. This allows tagbar
to cache the info so if the tagbar window is opened again, it doesn't
have to rescan the file and rerun ctags on the file.

However if this buffer is wiped out using `:bwipe <file>`, then the
buffer is completely unloaded from vim memory and also needs to be
unloaded from tagbar memory. This works if the tagbar window is open,
but in the event the tagbar window is closed, all autocmds are
unregistered, so tagbar never gets the BufWipeout notification. This
results in tagbar leaving the buffer in active memory even though the
buffer doesn't exist anymore.

This fix will leave the BufWipeout and BufDelete autocmds active even if
the tagbar window is closed. This allows the buffer cleanup to occur on
a `:bwipe` command even if the tagbar window is closed.