### PR TITLE
Potential fix for #772 - InitWindow issue

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -569,6 +569,8 @@ function! s:CreateAutocommands() abort
 
             autocmd WinEnter * if bufwinnr(s:TagbarBufName()) == -1 |
                         \     call s:ShrinkIfExpanded() |
+                        \ else |
+                        \     call s:InitWindow(g:tagbar_autoclose) |
                         \ endif
 
             autocmd BufWritePost *
@@ -968,6 +970,10 @@ endfunction
 function! s:InitWindow(autoclose) abort
     call tagbar#debug#log('InitWindow called with autoclose: ' . a:autoclose)
 
+    if exists('w:tagbar_win_init')
+        call tagbar#debug#log('InitWindow - already initialized this window')
+        return
+    endif
     " Buffer-local options
 
     setlocal filetype=tagbar
@@ -1051,6 +1057,7 @@ function! s:InitWindow(autoclose) abort
         let s:expand_bufnr = bufnr('%')
     endif
 
+    let w:tagbar_win_init = 1
     call tagbar#debug#log('InitWindow finished')
 endfunction
 
@@ -1109,6 +1116,7 @@ function! s:CloseWindow() abort
         call tagbar#StopAutoUpdate()
     endif
 
+    unlet w:tagbar_win_init
     call tagbar#debug#log('CloseWindow finished')
 endfunction
 


### PR DESCRIPTION
Potential fix for #772

This issue is being caused by the InitWindow() routine not being called
when a split of the tagbar window occurs. This will potentially fix that
issue by forceably calling s:InitWindow() when a new tagbar window is
found.

Note however, that when closing one of the split tagbar windows, it does
cause the other one to close as well. It looks like there is an issue on
the close processing that it identifies all windows that have the tagbar
buffer loaded as the tagbar window.