### PR TITLE
Better handling for typeinfo.deffile

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1390,11 +1390,6 @@ function! s:ExecuteCtagsOnFile(fname, realfname, typeinfo) abort
             let ctags_args += [ '-V' ]
         endif
 
-        " Include extra type definitions
-        if has_key(a:typeinfo, 'deffile')
-            let ctags_args += ['--options=' . expand(a:typeinfo.deffile)]
-        endif
-
         " Third-party programs may not necessarily make use of this
         if has_key(a:typeinfo, 'ctagstype')
             let ctags_type = a:typeinfo.ctagstype
@@ -1408,6 +1403,12 @@ function! s:ExecuteCtagsOnFile(fname, realfname, typeinfo) abort
 
             let ctags_args += ['--language-force=' . ctags_type]
             let ctags_args += ['--' . ctags_type . '-kinds=' . ctags_kinds]
+        endif
+
+        " Include extra type definitions - include last to allow for any
+        " overrides
+        if has_key(a:typeinfo, 'deffile') && filereadable(expand(a:typeinfo.deffile))
+            let ctags_args += ['--options=' . expand(a:typeinfo.deffile)]
         endif
     endif
 


### PR DESCRIPTION
Closes #776

Change the ordering of the --options field when executing ctags. This
allows overrides of things like the --<lang>-kinds definitions to omit
certain kinds.

Also add check to ensure the typeinfo.deffile exists before attempting
to use it in the ctags arguments.