### PR TITLE
Add JumpToNearbyTag functionality

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -2328,17 +2328,8 @@ endfunction
 
 " s:JumpToTag() {{{2
 function! s:JumpToTag(stay_in_tagbar, ...) abort
-    if a:0 > 0
-        let taginfo = a:1
-    else
-        let taginfo = s:GetTagInfo(line('.'), 1)
-    endif
-
-    if a:0 > 1
-        let force_lazy_scroll = a:2
-    else
-        let force_lazy_scroll = 0
-    endif
+    let taginfo = a:0 > 0 ? a:1 : s:GetTagInfo(line('.'), 1)
+    let force_lazy_scroll = a:0 > 1 ? a:2 : 0
 
     if empty(taginfo) || !taginfo.isNormalTag()
         return

--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -4046,12 +4046,17 @@ function! tagbar#jump() abort
     call s:JumpToTag(1)
 endfun
 
-" tagbar#jumpToNextTag() {{{2
+" tagbar#jumpToNearbyTag() {{{2
 " params:
 "   direction = -1:backwards search   1:forward search
-"   [lnum] = Line number to start searching from (default current line)
 "   [search_method] = Search method to use for GetTagNearLine()
-function! tagbar#jumpToNextTag(direction, ...) abort
+"   [lnum] = Line number to start searching from (default current line)
+function! tagbar#jumpToNearbyTag(direction, ...) abort
+    if a:0 >= 1
+        let search_method = a:1
+    else
+        let search_method = 'nearest-stl'
+    endif
     if a:0 >= 2
         let lnum = a:2
     else
@@ -4061,12 +4066,8 @@ function! tagbar#jumpToNextTag(direction, ...) abort
             let lnum = line('.') - 1
         endif
     endif
-    if a:0 >= 3
-        let search_method = a:3
-    else
-        let search_method = 'nearest-stl'
-    endif
 
+    echom 'direction:' . a:direction . ' search-method:' . search_method
     call s:JumpToNearbyTag(lnum, a:direction, search_method)
 endfunction
 

--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -4067,7 +4067,6 @@ function! tagbar#jumpToNearbyTag(direction, ...) abort
         endif
     endif
 
-    echom 'direction:' . a:direction . ' search-method:' . search_method
     call s:JumpToNearbyTag(lnum, a:direction, search_method)
 endfunction
 

--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -3157,17 +3157,11 @@ function! s:GetNearbyTag(request, forcecurrent, ...) abort
         return {}
     endif
 
+    let curline = a:0 > 0 ? a:1 : line('.')
+    let direction = a:0 > 1 ? a:2 : -1
+    let ignore_curline = a:0 > 2 ? a:3 : 0
+
     let typeinfo = fileinfo.typeinfo
-    if a:0 > 0
-        let curline = a:1
-    else
-        let curline = line('.')
-    endif
-    if a:0 > 1
-        let direction = a:2
-    else
-        let direction = -1
-    endif
     let tag = {}
 
     if direction < 0
@@ -3195,7 +3189,7 @@ function! s:GetNearbyTag(request, forcecurrent, ...) abort
                         \ && curline <= curtag.fields.end
                 let tag = curtag
                 break
-            elseif a:request ==# 'nearest' || line == curline
+            elseif a:request ==# 'nearest' || (line == curline && ignore_curline == 0)
                 let tag = curtag
                 break
             endif
@@ -3212,7 +3206,7 @@ function! s:JumpToNearbyTag(lnum, direction, request) abort
         return {}
     endif
 
-    let tag = s:GetNearbyTag(a:request, 1, a:lnum, a:direction)
+    let tag = s:GetNearbyTag(a:request, 1, a:lnum, a:direction, 1)
 
     if empty(tag)
         " No next tag found
@@ -4052,20 +4046,8 @@ endfun
 "   [search_method] = Search method to use for GetTagNearLine()
 "   [lnum] = Line number to start searching from (default current line)
 function! tagbar#jumpToNearbyTag(direction, ...) abort
-    if a:0 >= 1
-        let search_method = a:1
-    else
-        let search_method = 'nearest-stl'
-    endif
-    if a:0 >= 2
-        let lnum = a:2
-    else
-        if a:direction > 0
-            let lnum = line('.') + 1
-        else
-            let lnum = line('.') - 1
-        endif
-    endif
+    let search_method = a:0 >= 1 ? a:1 : 'nearest-stl'
+    let lnum = a:0 >= 2 ? a:2 : a:direction > 0 ? line('.') + 1 : line('.') - 1
 
     call s:JumpToNearbyTag(lnum, a:direction, search_method)
 endfunction

--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -3191,13 +3191,16 @@ function! s:GetNearbyTag(request, forcecurrent, ...) abort
 endfunction
 
 " s:JumpToNearbyTag() {{{2
-function! s:JumpToNearbyTag(lnum, direction, request) abort
+function! s:JumpToNearbyTag(direction, request, flags) abort
     let fileinfo = tagbar#state#get_current_file(0)
     if empty(fileinfo)
         return {}
     endif
 
-    let tag = s:GetNearbyTag(a:request, 1, a:lnum, a:direction, 1)
+    let lnum = a:direction > 0 ? line('.') + 1 : line('.') - 1
+    let lazy_scroll = a:flags =~# 's' ? 0 : 1
+
+    let tag = s:GetNearbyTag(a:request, 1, lnum, a:direction, 1)
 
     if empty(tag)
         " No next tag found
@@ -3209,7 +3212,7 @@ function! s:JumpToNearbyTag(lnum, direction, request) abort
         return
     endif
 
-    call s:JumpToTag(1, tag, 1)
+    call s:JumpToTag(1, tag, lazy_scroll)
 endfunction
 
 " s:GetTagInfo() {{{2
@@ -4035,12 +4038,13 @@ endfun
 " params:
 "   direction = -1:backwards search   1:forward search
 "   [search_method] = Search method to use for GetTagNearLine()
-"   [lnum] = Line number to start searching from (default current line)
+"   [flags] = list of flags (as a string) to control behavior
+"       's' - use the g:tagbar_scroll_offset setting when jumping
 function! tagbar#jumpToNearbyTag(direction, ...) abort
     let search_method = a:0 >= 1 ? a:1 : 'nearest-stl'
-    let lnum = a:0 >= 2 ? a:2 : a:direction > 0 ? line('.') + 1 : line('.') - 1
+    let flags = a:0 >= 2 ? a:2 : ''
 
-    call s:JumpToNearbyTag(lnum, a:direction, search_method)
+    call s:JumpToNearbyTag(a:direction, search_method, flags)
 endfunction
 
 " Modeline {{{1

--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -2330,10 +2330,14 @@ endfunction
 function! s:JumpToTag(stay_in_tagbar, ...) abort
     if a:0 > 0
         let taginfo = a:1
-        let autoclose = 0
     else
         let taginfo = s:GetTagInfo(line('.'), 1)
-        let autoclose = w:autoclose
+    endif
+
+    if a:0 > 1
+        let force_lazy_scroll = a:2
+    else
+        let force_lazy_scroll = 0
     endif
 
     if empty(taginfo) || !taginfo.isNormalTag()
@@ -2341,6 +2345,11 @@ function! s:JumpToTag(stay_in_tagbar, ...) abort
     endif
 
     let tagbarwinnr = winnr()
+    if exists('w:autoclose')
+        let autoclose = w:autoclose
+    else
+        let autoclose = 0
+    endif
 
     call s:GotoFileWindow(taginfo.fileinfo)
 
@@ -2350,7 +2359,7 @@ function! s:JumpToTag(stay_in_tagbar, ...) abort
     " Check if the tag is already visible in the window.  We must do this
     " before jumping to the line.
     let noscroll = 0
-    if g:tagbar_jump_lazy_scroll != 0
+    if g:tagbar_jump_lazy_scroll != 0 || force_lazy_scroll
         let noscroll = s:IsLineVisible(taginfo.fields.line)
     endif
 
@@ -3215,7 +3224,7 @@ function! s:JumpToNearbyTag(lnum, direction, request) abort
         return
     endif
 
-    call s:JumpToTag(0, tag)
+    call s:JumpToTag(1, tag, 1)
 endfunction
 
 " s:GetTagInfo() {{{2

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -401,11 +401,13 @@ FUNCTIONS                                                   *tagbar-functions*
     |tagbar#GetTagNearLine()| function call and behaves the same way. This
     will default to *'nearest-stl'* if not specified.
 
-    Can optionally provide a line number [lnum] to start searching from. It will
-    default to the current line if not provided.
+    Can optionally provide a flags field [flags] to control the nearby tag
+    jumping. The flags should be a string of characters with the following
+    meanings:
+        's' - use the |g:tagbar_scroll_off| setting when jumping
 
     Full syntax:
-        tagbar#jumpToNearbyTag(direction [, {search-method} [, {lnum}]])
+        tagbar#jumpToNearbyTag(direction [, {search-method} [, {flags}]])
 
     Examples:
 >
@@ -418,6 +420,11 @@ FUNCTIONS                                                   *tagbar-functions*
     " function calls, class definitions, variable definitions, typedefs, etc.
     nnoremap t] :call tagbar#jumpToNearbyTag(1, 'nearest')
     nnoremap t[ :call tagbar#jumpToNearbyTag(-1, 'nearest')
+
+    " These keymaps will jump to the next/prev tag regardless of type, and
+    " will also use the jump_offset configuration to position the cursor
+    nnoremap t] :call tagbar#jumpToNearbyTag(1, 'nearest', 's')
+    nnoremap t[ :call tagbar#jumpToNearbyTag(-1, 'nearest', 's')
 <
 
 ------------------------------------------------------------------------------

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -325,6 +325,20 @@ COMMANDS                                                     *tagbar-commands*
 
     This command will call the |tagbar#jump()| function.
 
+:TagbarJumpPrev                                             *:TagbarJumpPrev*
+    Jump to the previous tag under the cursor. This works in the file window.
+    This will search for the previous {'nearest-stl'} type tag starting at the
+    line just before the current line and do a backwards search.
+
+    This command will call the |tagbar#jumpToNextTag(-1)| function.
+
+:TagbarJumpNext                                             *:TagbarJumpNext*
+    Jump to the next tag under the cursor. This works in the file window.
+    This will search for the next {'nearest-stl'} type tag starting at the
+    line just after the current line and do a forward search.
+
+    This command will call the |tagbar#jumpToNextTag(1)| function.
+
 ------------------------------------------------------------------------------
 FUNCTIONS                                                   *tagbar-functions*
 
@@ -373,6 +387,30 @@ FUNCTIONS                                                   *tagbar-functions*
     the same behavior as the |p| key mapping.
 
     This is the function called when using the |:TagbarJump| command.
+
+*tagbar#jumpToNextTag()*
+    This function will jump to the next tag or previous tag starting a search
+    from the line under the cursor. This works when in the file window instead
+    of inside the tagbar window like the |tagbar#jump()| function.
+
+    The direction of search must be provided. If the [direction] is greater
+    than 0, then it will do a forward search. If the [direction] is less
+    than 0, then it will do a backward search.
+
+    Can optionally provide a line number [lnum] to start searching from. It will
+    default to the current line if not provided.
+
+    Can also optionally provide a [search_method] which is used in the
+    |tagbar#GetTagNearLine()| function call and behaves the same way.
+
+    Full syntax:
+        tagbar#jumpToNextTag(direction [, {lnum} [, {search-method}]])
+
+    Example:
+>
+    nnoremap t] :call tagbar#jumpToNextTag(1)
+    nnoremap t[ :call tagbar#jumpToNextTag(-1)
+<
 
 ------------------------------------------------------------------------------
 KEY MAPPINGS                                                     *tagbar-keys*

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -330,14 +330,14 @@ COMMANDS                                                     *tagbar-commands*
     This will search for the previous {'nearest-stl'} type tag starting at the
     line just before the current line and do a backwards search.
 
-    This command will call the |tagbar#jumpToNextTag(-1)| function.
+    This command will call the |tagbar#jumpToNearbyTag(-1)| function.
 
 :TagbarJumpNext                                             *:TagbarJumpNext*
     Jump to the next tag under the cursor. This works in the file window.
     This will search for the next {'nearest-stl'} type tag starting at the
     line just after the current line and do a forward search.
 
-    This command will call the |tagbar#jumpToNextTag(1)| function.
+    This command will call the |tagbar#jumpToNearbyTag(1)| function.
 
 ------------------------------------------------------------------------------
 FUNCTIONS                                                   *tagbar-functions*
@@ -388,7 +388,7 @@ FUNCTIONS                                                   *tagbar-functions*
 
     This is the function called when using the |:TagbarJump| command.
 
-*tagbar#jumpToNextTag()*
+*tagbar#jumpToNearbyTag()*
     This function will jump to the next tag or previous tag starting a search
     from the line under the cursor. This works when in the file window instead
     of inside the tagbar window like the |tagbar#jump()| function.
@@ -397,19 +397,27 @@ FUNCTIONS                                                   *tagbar-functions*
     than 0, then it will do a forward search. If the [direction] is less
     than 0, then it will do a backward search.
 
+    Can also optionally provide a [search_method] which is used in the
+    |tagbar#GetTagNearLine()| function call and behaves the same way. This
+    will default to *'nearest-stl'* if not specified.
+
     Can optionally provide a line number [lnum] to start searching from. It will
     default to the current line if not provided.
 
-    Can also optionally provide a [search_method] which is used in the
-    |tagbar#GetTagNearLine()| function call and behaves the same way.
-
     Full syntax:
-        tagbar#jumpToNextTag(direction [, {lnum} [, {search-method}]])
+        tagbar#jumpToNearbyTag(direction [, {search-method} [, {lnum}]])
 
-    Example:
+    Examples:
 >
-    nnoremap t] :call tagbar#jumpToNextTag(1)
-    nnoremap t[ :call tagbar#jumpToNextTag(-1)
+    " These keymaps will jump to the next/prev tag that can be scoped. Ex:
+    " function calls, class definitions, etc.
+    nnoremap t] :call tagbar#jumpToNearbyTag(1)
+    nnoremap t[ :call tagbar#jumpToNearbyTag(-1)
+
+    " These keymaps will jump to the next/prev tag regardless of type. Ex:
+    " function calls, class definitions, variable definitions, typedefs, etc.
+    nnoremap t] :call tagbar#jumpToNearbyTag(1, 'nearest')
+    nnoremap t[ :call tagbar#jumpToNearbyTag(-1, 'nearest')
 <
 
 ------------------------------------------------------------------------------

--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -197,6 +197,8 @@ command! -nargs=0 TagbarDebugEnd      call tagbar#debug#stop_debug()
 command! -nargs=0 TagbarTogglePause   call tagbar#toggle_pause()
 command! -nargs=0 TagbarForceUpdate   call tagbar#ForceUpdate()
 command! -nargs=0 TagbarJump   call tagbar#jump()
+command! -nargs=0 TagbarJumpPrev      call tagbar#jumpToNextTag(-1)
+command! -nargs=0 TagbarJumpNext      call tagbar#jumpToNextTag(1)
 
 
 " Modeline {{{1

--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -197,8 +197,8 @@ command! -nargs=0 TagbarDebugEnd      call tagbar#debug#stop_debug()
 command! -nargs=0 TagbarTogglePause   call tagbar#toggle_pause()
 command! -nargs=0 TagbarForceUpdate   call tagbar#ForceUpdate()
 command! -nargs=0 TagbarJump   call tagbar#jump()
-command! -nargs=0 TagbarJumpPrev      call tagbar#jumpToNextTag(-1)
-command! -nargs=0 TagbarJumpNext      call tagbar#jumpToNextTag(1)
+command! -nargs=0 TagbarJumpPrev      call tagbar#jumpToNearbyTag(-1)
+command! -nargs=0 TagbarJumpNext      call tagbar#jumpToNearbyTag(1)
 
 
 " Modeline {{{1


### PR DESCRIPTION
Closes #779

Updated functions:

`s:GetNearbyTag()` - Allow for a direction parameter to be passed into the routine. This will allow for a forward or backward search. It will default to a backward search line the current behavior if the `a:direction` parameter is not used.

`s:JumpToTag()` - Allow for an optional parameter to be passed in to specify the tag instead of using the tag under the cursor on the current line. This also allows this routine to be executed from the file window instead of the tagbar window. Assume `autoclose=0` if passing in the tag.

Add new functions:

`s:JumpToNearbyTag()` - This routine will do a forward or backward search for the nearst tag using the `GetNearbyTag()` with the new direction field, then call the `JumpToTag()` with the tag we found.

`tagbar#jumpToNextTag()` - New public facing wrapper routine around the `JumpToNearbyTag()` routine. Optionally take in `a:lnum` and `a:search_method` to be used in other routines. If `a:lnum` is not present, then the line number will search from the next or previous line depending on the `a:direction` value.

TODO:
- [x] Still need to write up the documentation for this.
- [x] Possibly look at providing default keymap. Currently this can be done using a custom definition in `.vimrc`.
