### PR TITLE
Add ability to fold/unfold headers on <CR> in tagbar window

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -2333,6 +2333,23 @@ function! s:JumpToTag(stay_in_tagbar) abort
     let autoclose = w:autoclose
 
     if empty(taginfo) || !taginfo.isNormalTag()
+        " Cursor line not on a tag. Check if this is the start of a foldable
+        " line and if so, initiate the CloseFold() / OpenFold(). First trim
+        " any whitespace from the start of the line so we don't have to worry
+        " about multiple nested folds that are indented
+        "
+        " NOTE: This will only work with folds that are not also tags. For
+        " example in a class definition that acts as the start of a fold when
+        " there are member functions in the class, that line is also a valid
+        " tag, so hitting <CR> on that line will cause it to jump to the tag,
+        " not fold/unfold that particular fold
+        let line   = substitute(getline('.'), '^\s*\(.\{-}\)\s*$', '\1', '')
+
+        if (match(line, g:tagbar#icon_open . '[-+ ]')) == 0
+            call s:CloseFold()
+        elseif (match(line, g:tagbar#icon_closed . '[-+ ]')) == 0
+            call s:OpenFold()
+        endif
         return
     endif
 

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -212,6 +212,10 @@ by moving the cursor to a tag and pressing <Enter> or double-clicking on it
 with the mouse. The source file will then move to the definition and put the
 cursor in the corresponding line. This won't work for pseudo-tags.
 
+If the current line of the tagbar window is not on a tag, for example on the
+'functions' tag-kind and <Enter> is hit, then that tag-kind will be folded or
+unfolded if possible.
+
 Sorting~
 You can sort the tags in the Tagbar window in two ways: by name or by file
 order. Sorting them by name simply displays the tags in their alphabetical
@@ -381,8 +385,8 @@ The following mappings are valid in the Tagbar window:
 
 <F1>/?        Display key mapping help.
                 Map option: tagbar_map_help
-<CR>/<Enter>  Jump to the tag under the cursor. Doesn't work for pseudo-tags
-              or generic headers.
+<CR>/<Enter>  Jump to the tag under the cursor. Doesn't work for pseudo-tags.
+              If on generic header, it will fold/unfold that header.
                 Map option: tagbar_map_jump
 p             Jump to the tag under the cursor, but stay in the Tagbar window.
                 Map option: tagbar_map_preview


### PR DESCRIPTION
Closes #778

Add to the `JumpToTag()` routine so if the current line does not contain
a valid tag, then it will check if the line is foldable, and if so will
either call the `OpenFold()` or `CloseFold()` as necessary. This allows
the `<Enter>` key to be used to toggle a foldable header in the tagbar
window.