### PR TITLE
Fix for #784 - add additional option for `g:tagbar_wrap`

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1003,6 +1003,11 @@ function! s:InitWindow(autoclose) abort
         if exists('+linebreak')
             setlocal breakindent
             setlocal breakindentopt=shift:4
+            if g:tagbar_wrap == 1
+                setlocal linebreak
+            elseif g:tagbar_wrap == 2
+                setlocal nolinebreak
+            endif
         endif
     endif
 

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -1048,17 +1048,53 @@ Example:
 g:tagbar_wrap~
 Default: 0
 
-If set to non-zero, this will enable line wrapping on the tagbar window. This
-option will use the built-in |wrap| vim option on the tagbar window to
-enable line wrapping. This also will use the |breakindent| and
-|breakindentopt| options in vim to set the indentation of the wrapped lines.
+Possible Values:
+    0   Disable line wrapping.
+    1   Enable the |wrap| option and also enable the |linebreak| option to
+        split the lines on word boundaries. This will use the default
+        |breakat| setting in vim. Note: This can cause possible display issues
+        with tags that exceed the tagbar window width. A very long tag name
+        will cause the tag itself to wrap resulting in an empty line and
+        indentation of the tag (see example below).
+    2   Enable the |wrap| option but disable the |linebreak| option. This will
+        split the lines at the end of the tagbar window and can cause it to
+        wrap in the middle of a word. This should be used if there are tags
+        that are regularly longer than the tagbar window width.
+
+This also will use the |breakindent| and |breakindentopt| options in vim to
+set the indentation of the wrapped lines.
 
 Note: This requires VIM to be compiled with the |+linebreak| option for the
 wrap intentation to function.
 
-Example:
+Examples:
 >
+       " Wrap with linebreak - note the wrap works on word boundaries, but
+       " a very long tag name does cause an odd display issue.
        let g:tagbar_wrap = 1
+       +-------------------------------------------+
+       | ⯆ functions (106)                         |
+       |     s:add_tag_recursive(parent,taginfo,   |
+       |         pathlist) : function!             |
+       |     s:AutoUpdate(fname,force,...) :       |
+       |         function!                         |
+       |                                           |
+       |         s:SomeReallyLongTagNameThatWillExc|
+       |         eedWindowWidth : function!        |
+       +-------------------------------------------+
+
+       " Wrap without linbreak - note the display issue is gone for the
+       " really long tag name, but the other wraps will breakup words.
+       let g:tagbar_wrap = 2
+       +-------------------------------------------+
+       | ⯆ functions (106)                         |
+       |     s:add_tag_recursive(parent,taginfo,pat|
+       |         hlist) : function!                |
+       |     s:AutoUpdate(fname,force,...) : functi|
+       |         on!                               |
+       |     s:SomeReallyLongTagNameThatWillExceedW|
+       |         indowWidth : funciton!            |
+       +-------------------------------------------+
 <
                                                         *g:tagbar_no_autocmds*
 g:tagbar_no_autocmds~


### PR DESCRIPTION
Closes #784 

Adding additional setting to `g:tagbar_wrap` to allow for more granular
control of the `linebreak` functionality. If set to 1, linebreak will
also be set. If set to 2, linebreak will be disabled.

`g:tagbar_wrap` was added in #659