### PR TITLE
feature: Add basic Crystal support

### DIFF
--- a/autoload/tagbar/types/ctags.vim
+++ b/autoload/tagbar/types/ctags.vim
@@ -195,6 +195,21 @@ function! tagbar#types#ctags#init(supported_types) abort
         \ {'short' : 's', 'long' : 'sections',          'fold' : 0, 'stl' : 1}
     \ ]
     let types.cobol = type_cobol
+    " Crystal {{{1
+    let type_crystal = tagbar#prototypes#typeinfo#new()
+    let type_crystal.ctagstype = 'crystal'
+    let type_crystal.kinds     = [
+        \ {'short' : 'm', 'long' : 'modules',           'fold' : 0, 'stl' : 1},
+        \ {'short' : 'c', 'long' : 'classes',           'fold' : 0, 'stl' : 1},
+        \ {'short' : 'd', 'long' : 'defs',              'fold' : 0, 'stl' : 1},
+        \ {'short' : 'f', 'long' : 'functions',         'fold' : 0, 'stl' : 1},
+        \ {'short' : 'M', 'long' : 'macros',            'fold' : 0, 'stl' : 1},
+        \ {'short' : 'l', 'long' : 'libs',              'fold' : 0, 'stl' : 1},
+        \ {'short' : 's', 'long' : 'structs',           'fold' : 0, 'stl' : 1},
+        \ {'short' : 'a', 'long' : 'aliases',           'fold' : 0, 'stl' : 1}
+    \ ]
+    let type_crystal.sro        = '::'
+    let types.crystal = type_crystal
     " DOS Batch {{{1
     let type_dosbatch = tagbar#prototypes#typeinfo#new()
     let type_dosbatch.ctagstype = 'dosbatch'

--- a/autoload/tagbar/types/uctags.vim
+++ b/autoload/tagbar/types/uctags.vim
@@ -319,6 +319,21 @@ function! tagbar#types#uctags#init(supported_types) abort
         \ 'function'  : 'f',
     \ }
     let types.cmake = type_cmake
+    " Crystal {{{1
+    let type_crystal = tagbar#prototypes#typeinfo#new()
+    let type_crystal.ctagstype = 'crystal'
+    let type_crystal.kinds     = [
+        \ {'short' : 'm', 'long' : 'modules',           'fold' : 0, 'stl' : 1},
+        \ {'short' : 'c', 'long' : 'classes',           'fold' : 0, 'stl' : 1},
+        \ {'short' : 'd', 'long' : 'defs',              'fold' : 0, 'stl' : 1},
+        \ {'short' : 'f', 'long' : 'functions',         'fold' : 0, 'stl' : 1},
+        \ {'short' : 'M', 'long' : 'macros',            'fold' : 0, 'stl' : 1},
+        \ {'short' : 'l', 'long' : 'libs',              'fold' : 0, 'stl' : 1},
+        \ {'short' : 's', 'long' : 'structs',           'fold' : 0, 'stl' : 1},
+        \ {'short' : 'a', 'long' : 'aliases',           'fold' : 0, 'stl' : 1}
+    \ ]
+    let type_crystal.sro        = '::'
+    let types.crystal = type_crystal
     " Ctags config {{{1
     let type_ctags = tagbar#prototypes#typeinfo#new()
     let type_ctags.ctagstype = 'ctags'


### PR DESCRIPTION
The Crystal [~/.ctags](https://github.com/dammer/crystal-ctags) file is need to work.

![Peek 2021-08-05 22-05](https://user-images.githubusercontent.com/274366/128407769-079e413f-59b5-4df3-bdb3-4d4ef36ed0fc.gif)

Fixes #517  
