### PR TITLE
Clear old TagbarCleanupAutoCmds before redefining

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -597,6 +597,8 @@ function! s:CreateAutocommands() abort
     " Separate these autocmds out from the others as we want to always perform
     " these actions even if the tagbar window closes.
     augroup TagbarCleanupAutoCmds
+        autocmd!
+
         if !g:tagbar_no_autocmds
             autocmd BufDelete,BufWipeout *
                         \ nested call s:HandleBufDelete(expand('<afile>'), expand('<abuf>'))


### PR DESCRIPTION
This fixes a performance issue where, during long editing sessions, tagbar was causing buffer deletes/wipeouts to take longer and longer, owing to the ever longer list of autocommands tagbar would execute. This could be a particular issue when heavily using other plugins that clean up their buffers when finished with them.