### PR TITLE
Allow addition of new language types (#789)

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1397,6 +1397,12 @@ function! s:ExecuteCtagsOnFile(fname, realfname, typeinfo) abort
             let ctags_args += [ '-V' ]
         endif
 
+        " Define a new language before adding --language-force to the list of
+        " arguments
+        if has_key(a:typeinfo, 'deflang')
+            let ctags_args += ['--langdef=' . expand(a:typeinfo.deflang)]
+        endif
+
         " Third-party programs may not necessarily make use of this
         if has_key(a:typeinfo, 'ctagstype')
             let ctags_type = a:typeinfo.ctagstype


### PR DESCRIPTION
This is an attempt to resolve #789 and re-enable support for addition of a new language definition from within vim configuration without having to edit `~/.ctags`.

With this patch, if you need to define a language that is unknown to ctags and provide a custom file with `deffile` as documented in `doc/tagbar.txt`, you can use `deflang` as follows:

```vim
let g:tagbar_type_asciidoc = {
  \ 'ctagstype': 'asciidoc',
  \ 'deflang': 'asciidoc',
  \ 'deffile': expand('<sfile>:p:h:h') . '/ctags/asciidoc.cnf',
  \ 'sort': 0,
  \ 'kinds': [
    \ 's:Table of Contents',
    \ 'i:Included Files',
    \ 'I:Images',
    \ 'v:Videos',
    \ 'a:Set Attributes',
    \ 'A:Unset Attributes'
  \ ]
\}
```