### PR TITLE
Fix for #783 - set colorcolumn to empty string (default) for local tagbar window

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -981,6 +981,7 @@ function! s:InitWindow(autoclose) abort
     setlocal nobuflisted
     setlocal nomodifiable
     setlocal textwidth=0
+    setlocal colorcolumn=""
 
     if g:tagbar_scrolloff > 0
         execute 'setlocal scrolloff=' . g:tagbar_scrolloff


### PR DESCRIPTION
Closes #783 

Do a `setlocal colorcolumn=""` for the tagbar window initialization to disable the colorcolumn feature in the tagbar window. As per vim documentation, the `colorcolumn` field is a string and defaults to an empty string.