### PR TITLE
Add support for powershell

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -2992,7 +2992,7 @@ function! s:EscapeCtagsCmd(ctags_bin, args, ...) abort
 
     "Set up 0th argument of ctags_cmd
     "a:ctags_bin may have special characters that require escaping.
-    if &shell =~? 'cmd\.exe$' && a:ctags_bin !~# '\s'
+    if (&shell =~? 'cmd\.exe$' || &shell =~? 'powershell\.exe$' || &shell =~? 'powershell$' || &shell =~? 'pwsh\.exe$' || &shell =~? 'pwsh$') && a:ctags_bin !~# '\s'
         "For windows cmd.exe, escaping the 0th argument can cause
         "problems if it references a batch file and the batch file uses %~dp0.
         "So for windows cmd.exe, only escape the 0th argument iff necessary.


### PR DESCRIPTION
I use tagbar on Windows 10, and made a small change to allow tagbar to work when powershell is being used as the vim shell.

Before this change, when opening a tagbar window I receive the misleading message "Ctags doesn't seem to be Exuberant Ctags!" that was reported in issues https://github.com/preservim/tagbar/issues/424 and https://github.com/preservim/tagbar/issues/628.

After the change, I am able to use tagbar with either the original Windows powershell (powershell.exe) or the newer open-source powershell (pwsh.exe).

The change works in both neovim and vim, but I found a posting (https://groups.google.com/g/vim_dev/c/Hcega_rfWOQ?pli=1) that highlights a separate problem using powershell in vim.  In vim, the &shellquote variable is automatically set to double-quote (")  when running on Windows whenever &shell contains the string 'sh' (mentioned in the vim powershell help), which breaks powershell commands.  To work around the issue, I set &shell to 'pwSh.exe' with an uppercase 'S' in my _vimrc file.  In neovim, this problem does not occur.
