### PR TITLE
Add support of TagbarOpen arguments for TagbarToggle

### DIFF
--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -270,9 +270,11 @@ COMMANDS                                                     *tagbar-commands*
 :TagbarClose                                                    *:TagbarClose*
     Close the Tagbar window if it is open.
 
-:TagbarToggle                                                  *:TagbarToggle*
-:Tagbar
+:TagbarToggle [{flags}]                                        *:TagbarToggle*
+:Tagbar [{flags}]
     Open the Tagbar window if it is closed, or close it if it is open.
+    Additional behaviour can be specified with the same optional {flags}
+    argument as :TagbarOpen.
 
 :TagbarOpenAutoClose                                    *:TagbarOpenAutoClose*
     Open the Tagbar window, jump to it and close it on tag selection. This is

--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -183,8 +183,8 @@ augroup TagbarSession
 augroup END
 
 " Commands {{{1
-command! -nargs=0 Tagbar              call tagbar#ToggleWindow()
-command! -nargs=0 TagbarToggle        call tagbar#ToggleWindow()
+command! -nargs=? Tagbar              call tagbar#ToggleWindow(<f-args>)
+command! -nargs=? TagbarToggle        call tagbar#ToggleWindow(<f-args>)
 command! -nargs=? TagbarOpen          call tagbar#OpenWindow(<f-args>)
 command! -nargs=0 TagbarOpenAutoClose call tagbar#OpenWindow('fcj')
 command! -nargs=0 TagbarClose         call tagbar#CloseWindow()


### PR DESCRIPTION
I needed TagbarToggle to pass arguments to TagbarOpen. It was already implemented in TagbarToggle() but not in the command. So it is.