### PR TITLE
Only set ballooneval while in tagbar window

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -563,6 +563,16 @@ function! s:CreateAutocommands() abort
             autocmd WinEnter   __Tagbar__.* call s:SetStatusLine()
             autocmd WinLeave   __Tagbar__.* call s:SetStatusLine()
 
+            if g:tagbar_show_balloon == 1 && has('balloon_eval')
+                autocmd WinEnter __Tagbar__.*
+                        \ let s:beval = &beval |
+                        \ set ballooneval
+                autocmd WinLeave __Tagbar__.*
+                        \ if exists("s:beval") |
+                        \   let &beval = s:beval |
+                        \ endif
+            endif
+
             if g:tagbar_autopreview
                 autocmd CursorMoved __Tagbar__.* nested call s:ShowInPreviewWin()
             endif
@@ -989,7 +999,6 @@ function! s:InitWindow(autoclose) abort
 
     if g:tagbar_show_balloon == 1 && has('balloon_eval')
         setlocal balloonexpr=TagbarBalloonExpr()
-        set ballooneval
     endif
 
 


### PR DESCRIPTION
ballooneval is a global option, so setting it while initialising tagbar
permanently enables ballooneval functionality for the GUI, overriding
the vim default (disabled) or a user explicitly setting noballooneval.

To address this, only set ballooneval when entering the tagbar window,
and restore the original ballooneval setting when leaving the window.

This is not perfect, but there is precedent, Netrw behaves like this.

Fixes #499 