### PR TITLE
Use tagbar_iconchars not present in emoji

### DIFF
--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -135,7 +135,7 @@ call s:setup_options()
 if !exists('g:tagbar_iconchars')
     if has('multi_byte') && has('unix') && &encoding ==# 'utf-8' &&
      \ (!exists('+termencoding') || empty(&termencoding) || &termencoding ==# 'utf-8')
-        let g:tagbar_iconchars = ['▶', '▼']
+        let g:tagbar_iconchars = ['▸', '▾']
     else
         let g:tagbar_iconchars = ['+', '-']
     endif


### PR DESCRIPTION
The previous tagbar_iconchars, specifically "▶" (U+25B6), has a representation in emoji which can display strangely in some terminal emulators. Simply using triangle characters that don't overlap with emoji resolves the issue.