### PR TITLE
Don't show errors when opening preview window 

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -2500,7 +2500,7 @@ function! s:ShowInPreviewWin() abort
     " Open the preview window if it is not already open. This has to be done
     " explicitly before the :psearch below to better control its positioning.
     if !pwin_open
-        silent execute
+        silent! execute
             \ g:tagbar_previewwin_pos . ' pedit ' .
             \ fnameescape(taginfo.fileinfo.fpath)
         if g:tagbar_position !~# 'vertical'

--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -2500,9 +2500,12 @@ function! s:ShowInPreviewWin() abort
     " Open the preview window if it is not already open. This has to be done
     " explicitly before the :psearch below to better control its positioning.
     if !pwin_open
+        let l:confirm = &confirm
+        let &confirm = 0
         silent! execute
             \ g:tagbar_previewwin_pos . ' pedit ' .
             \ fnameescape(taginfo.fileinfo.fpath)
+        let &confirm = l:confirm
         if g:tagbar_position !~# 'vertical'
             silent execute 'vertical resize ' . g:tagbar_width
         endif


### PR DESCRIPTION
I was experiencing an issue where, if the current buffer had unsaved changes, the action of opening the preview window on a tagbar tag would cause an error that would require a keypress to dismiss. I found this jarring and simply updated the `pedit` command to fail silently.

I'm hoping that someone else finds this useful, or perhaps there's a better solution than just ignoring the error.

Cheers!