### PR TITLE
Fixes #811, #799: Add language specific regex support for custom tag kinds

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1427,6 +1427,12 @@ function! s:ExecuteCtagsOnFile(fname, realfname, typeinfo) abort
         if has_key(a:typeinfo, 'deffile') && filereadable(expand(a:typeinfo.deffile))
             let ctags_args += ['--options=' . expand(a:typeinfo.deffile)]
         endif
+
+        if has_key(a:typeinfo, 'regex')
+            for regex in a:typeinfo.regex
+                let ctags_args += ['--regex-' . ctags_type . '=' . regex]
+            endfor
+        endif
     endif
 
     if has_key(a:typeinfo, 'ctagsbin')

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -1664,7 +1664,7 @@ ctagsargs: The arguments to be passed to the filetype-specific ctags program
                        \ 's:structs:0:1',
                        \ 'm:members:1:0',
                        \ 'v:variables:0:0',
-                       \ 'f:functions:0:1:
+                       \ 'f:functions:0:1',
                        \ 'T:todo:0:0',
                    \ ],
                    \ 'sro'          : '::',

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -1637,6 +1637,47 @@ ctagsargs: The arguments to be passed to the filetype-specific ctags program
 
            If special escaping is required for different OS shell types or if
            in doubt, then it is recommended to define ctagsargs with a List.
+ regex:    A list of regular expression arguments that will be provided to
+           ctags via a '--regex-<lang>=<regex>' option. Multiple regular
+           expressions can be provded to allow adding support for multiple new
+           tag regular expressions. The regex statement should be formatted as
+           documented in the ctags documentation.
+            https://docs.ctags.io/en/latest/optlib.html#regex-option-argument-flags
+           When adding a regex statement, the corresponding tag kind label
+           will need to be defined in the |kinds| definition in the structure
+           as well. An example for a 'TODO' label for the c language would be
+           as follows (note: use of the '{_anonymous=..}' option is not
+           strictly necessary, but does give a unique tag name for each match):
+>
+               let g:tagbar_type_c = {
+                   \ 'ctagstype'    : 'c',
+                   \ 'regex'        : [
+                       \ '/(TODO).*//T,ToDo,ToDo Messages/{_anonymous=todo_}',
+                   \ ],
+                   \ 'kinds'        : [
+                       \ 'h:header files:1:0',
+                       \ 'd:macros:1:0',
+                       \ 'p:prototypes:1:0',
+                       \ 'g:enums:0:1',
+                       \ 'e:enumerators:0:0',
+                       \ 't:typedefs:0:0',
+                       \ 's:structs:0:1',
+                       \ 'm:members:1:0',
+                       \ 'v:variables:0:0',
+                       \ 'f:functions:0:1:
+                       \ 'T:todo:0:0',
+                   \ ],
+                   \ 'sro'          : '::',
+                   \ 'kind2scope'	: {
+                        \ 'g' : 'enum',
+                        \ 's' : 'struct',
+                   \ },
+                   \ 'scope2kind'	: {
+                        \ 'enum'   : 'g',
+                        \ 'struct' : 's',
+                   \ }
+                \ }
+<
 
 
 You then have to assign this dictionary to a variable in your vimrc with the


### PR DESCRIPTION
Fixes #811 and #799

This will add custom tag kind support on a per-language level. It is not feasible to provide a global definition as the tag kind identifier must be unique, and each language has a different set of kinds defined for it. So this way we can at least allow a per-language custom definition for any custom tags that the user may wish to add using a `--regex-<lang>=<regex>` option for the ctags command. This will be flexible enough to allow adding the `TODO` type tag kinds as requested in #811, but will also provide a framework for a more general approach to allow any custom tag kinds to be added based on what the user is needing.

For the case in #799, we can add the following regex definition. Note: this does not allow for scope information for the function, but it does at least provide an option for the `async <function> (<args>)` type syntax which is better than what we have today.
```vim
let g:tagbar_type_javascript = {
        \ 'ctagstype'	: 'javascript',
        \ 'regex'		: [
            \ '/async[ \t]+(.*)[ \t]*\(.*\)/\1/f/func/function/',
        \ ],
        ... # Rest of the definition here
    \ }
```