### PR TITLE
add 'on' for mixin

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -266,6 +266,7 @@ function! s:InitTypes() abort
             \ {'short' : 'd', 'long' : 'extends',            'fold' : 0, 'stl' : 0},
             \ {'short' : 'w', 'long' : 'with',               'fold' : 0, 'stl' : 0},
             \ {'short' : 'z', 'long' : 'implements',         'fold' : 0, 'stl' : 0},
+            \ {'short' : 'n', 'long' : 'on',                 'fold' : 0, 'stl' : 0},
             \ {'short' : 'r', 'long' : 'constructors',       'fold' : 0, 'stl' : 0},
             \ {'short' : 'a', 'long' : 'abstract functions', 'fold' : 0, 'stl' : 0},
             \ {'short' : 'f', 'long' : 'fields',             'fold' : 0, 'stl' : 0},


### PR DESCRIPTION
Hi, I'm maintaining Tagbar for Dart & flutter.

and I found lack of `Declaration` that `on` of mixin. 

I already Tested on my `dart_ctags`.  works well.


![Screenshot from 2022-04-30 14-21-38](https://user-images.githubusercontent.com/54878755/166094532-4a36a5ab-5314-48fb-9ea3-df3dc7768a91.png)
