### PR TITLE
Allow autocmds in the host window when s:JumpToTag() leaves the tagbar

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -883,7 +883,7 @@ function! s:OpenWindow(flags) abort
     if tagbarwinnr != -1
         if winnr() != tagbarwinnr && jump
             call s:goto_win(tagbarwinnr)
-            call s:HighlightTag(g:tagbar_autoshowtag != 2, 1, curline)
+            call s:HighlightTag(g:tagbar_autoshowtag != 2, 1, 1, curline)
         endif
         call tagbar#debug#log('OpenWindow finished, Tagbar already open')
         return
@@ -949,7 +949,7 @@ function! s:OpenWindow(flags) abort
     endif
 
     call s:AutoUpdate(curfile, 0)
-    call s:HighlightTag(g:tagbar_autoshowtag != 2, 1, curline)
+    call s:HighlightTag(g:tagbar_autoshowtag != 2, 1, 1, curline)
 
     if !(g:tagbar_autoclose || autofocus || g:tagbar_autofocus)
         if exists('*win_getid')
@@ -2252,12 +2252,14 @@ function! s:HighlightTag(openfolds, ...) abort
         return
     endif
 
+    let noauto = a:0 > 0 ? a:1 : 0
+
     let tagline = 0
 
-    let force = a:0 > 0 ? a:1 : 0
+    let force = a:0 > 1 ? a:2 : 0
 
-    if a:0 > 1
-        let tag = s:GetNearbyTag(g:tagbar_highlight_method, 0, a:2)
+    if a:0 > 2
+        let tag = s:GetNearbyTag(g:tagbar_highlight_method, 0, a:3)
     else
         let tag = s:GetNearbyTag(g:tagbar_highlight_method, 0)
     endif
@@ -2335,7 +2337,7 @@ function! s:HighlightTag(openfolds, ...) abort
     finally
         if !in_tagbar
             call s:goto_win(pprevwinnr, 1)
-            call s:goto_win(prevwinnr, 1)
+            call s:goto_win(prevwinnr, noauto)
         endif
         redraw
     endtry
@@ -2461,7 +2463,7 @@ function! s:JumpToTag(stay_in_tagbar, ...) abort
     normal! zv
 
     if a:stay_in_tagbar
-        call s:HighlightTag(0)
+        call s:HighlightTag(0, 1)
         call s:goto_win(tagbarwinnr)
         redraw
     elseif g:tagbar_autoclose || autoclose
@@ -2933,7 +2935,7 @@ function! s:AutoUpdate(fname, force, ...) abort
         let s:nearby_disabled = 0
     endif
 
-    call s:HighlightTag(0)
+    call s:HighlightTag(0, 1)
     call s:SetStatusLine()
     call tagbar#debug#log('AutoUpdate finished successfully')
 endfunction
@@ -3792,7 +3794,7 @@ function! tagbar#highlighttag(openfolds, force) abort
         echohl None
         return
     endif
-    call s:HighlightTag(a:openfolds, a:force)
+    call s:HighlightTag(a:openfolds, 1, a:force)
 endfunction
 
 function! tagbar#RestoreSession() abort


### PR DESCRIPTION
This fixes cursor splashing in wrong positions when plugin [Beacon](https://github.com/DanilaMihailov/beacon.nvim) is enabled.

Recently I installed the Beacon plugin and found that cursor splashes it runs on `WinEnter` after the cursor jumps from the tagbar to the host window happen in wrong places (the top or the bottom line of the host window). The following animation shows what happens:

![Peek 2022-06-08 23-51](https://user-images.githubusercontent.com/1219667/172792567-525dcd7d-5778-48ca-a5a4-1ec6a001b2d3.gif)

Note that splashes occur at the top and the bottom lines of the host window when the tag gets chosen in the tagbar and the cursor jumps back to the host window.

The reason is that `s:JumpToTag()` makes jump with `noautocmd` on.

Look what it does (this is the original, not yet changed code):

```vim
    if a:stay_in_tagbar
        call s:HighlightTag(0)
        call s:goto_win(tagbarwinnr)
        redraw
    elseif g:tagbar_autoclose || autoclose
        " Also closes preview window
        call s:CloseWindow()
    else
        " Close the preview window if it was opened by us
        if s:pwin_by_tagbar
            pclose
        endif
        if s:is_maximized
            call s:ZoomWindow()
        endif
        call s:HighlightTag(0)
    endif
```

There are 3 cases:

1. Stay in the tagbar after jump -> call `s:HighlightTag()` -> `noautocmd` in the host window, that's Ok as we are not moving from the tagbar.
2. Autoclose tagbar -> autocmds are on as `s:CloseWindow()` runs them, that's Ok too.
3. Jump from the tagbar window to the host window -> call `s:HighlightTag()` -> `noautocmd` in the host window, that seems to be Not Ok as the cursor physically moves to the host window.

Function `s:HighlightTag()` calls `s:goto_win()` with `noautocmd` flag. In this PR I extended trailing arguments of `s:HighlightTag()` to let `s:JumpToTag()` call this with the unset `noautocmd` flag passed to `s:goto_win()` for the host window in the case 3.

After the fix, the Beacon cursor splashes occur in the right positions.

![Peek 2022-06-08 23-49](https://user-images.githubusercontent.com/1219667/172796968-1f010869-fce0-4250-a35a-8f1b05e009a4.gif)