### PR TITLE
Add `autoclose_netrw` configuration option

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -3509,7 +3509,15 @@ function! s:HandleOnlyWindow() abort
     let vim_quitting = s:vim_quitting
     let s:vim_quitting = 0
 
-    if vim_quitting && !s:HasOpenFileWindows()
+    let file_open = s:HasOpenFileWindows()
+
+    if vim_quitting && file_open == 2 && !g:tagbar_autoclose_netrw
+        call tagbar#debug#log('Closing Tagbar due to QuitPre - netrw only remaining window')
+        call s:CloseWindow()
+        return
+    endif
+
+    if vim_quitting && file_open != 1
         call tagbar#debug#log('Closing Tagbar window due to QuitPre event')
         if winnr('$') >= 1
             call s:goto_win(tagbarwinnr, 1)
@@ -3627,11 +3635,22 @@ endfunction
 
 " s:HasOpenFileWindows() {{{2
 function! s:HasOpenFileWindows() abort
+    let netrw = 0
+
     for i in range(1, winnr('$'))
         let buf = winbufnr(i)
 
-        " skip unlisted buffers, except for netrw
-        if !buflisted(buf) && getbufvar(buf, '&filetype') !=# 'netrw'
+        " If the buffer filetype is netrw (or nerdtree) then mark netrw
+        " for final return. If we don't find any other window, we want
+        " to leave the netrw window open and not close vim entirely when
+        " called from the HandleOnlyWindow() code path.
+        let buf_ft = getbufvar(buf, '&filetype')
+        if buf_ft ==# 'netrw' || buf_ft == 'nerdtree'
+            let netrw = 1
+        endif
+
+        " skip unlisted buffers
+        if !buflisted(buf)
             continue
         endif
 
@@ -3648,6 +3667,10 @@ function! s:HasOpenFileWindows() abort
         return 1
     endfor
 
+    if netrw
+        call tagbar#debug#log('netrw only window remaining')
+        return 2
+    endif
     return 0
 endfunction
 

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -660,6 +660,23 @@ Example:
         let g:tagbar_autoclose = 1
 <
 
+                                                    *g:tagbar_autoclose_netrw*
+g:tagbar_autoclose_netrw~
+Default: 1
+
+This option is used to control the behavior when tagbar is the last window
+open, but the netrw (or nerdtree) window is also open. If this value is set to
+1, that will indicate that vim should be closed if tagbar and netrw are the
+last windows open. If you set this to 0 and tagbar and the netrw (or nerdtree)
+windows are the only remaining windows, then it will still close the tagbar
+window, however it will leave vim open with the netrw (or nerdtree) window
+open.
+
+Example:
+>
+        let g:tagbar_autoclose_netrw = 0
+<
+
                                                           *g:tagbar_autofocus*
 g:tagbar_autofocus~
 Default: 0

--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -85,6 +85,7 @@ function! s:setup_options() abort
     endif
     let options = [
         \ ['autoclose', 0],
+        \ ['autoclose_netrw', 1],
         \ ['autofocus', 0],
         \ ['autopreview', 0],
         \ ['autoshowtag', 0],


### PR DESCRIPTION
Closes #821

This will add the `autoclose_netrw` configuration option. If set to 1
this will close out of vim if tagbar and netrw (or nerdtree) are the
only remaining windows. If set to 0, then this will leave the netrw (or
nerdtree) window if that is the only remaining window once tagbar is
closed.