### PR TITLE
Update the `autoclose_netrw` default value based on community feedback

### DIFF
--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -662,7 +662,7 @@ Example:
 
                                                     *g:tagbar_autoclose_netrw*
 g:tagbar_autoclose_netrw~
-Default: 1
+Default: 0
 
 This option is used to control the behavior when tagbar is the last window
 open, but the netrw (or nerdtree) window is also open. If this value is set to
@@ -674,7 +674,7 @@ open.
 
 Example:
 >
-        let g:tagbar_autoclose_netrw = 0
+        let g:tagbar_autoclose_netrw = 1
 <
 
                                                           *g:tagbar_autofocus*

--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -85,7 +85,7 @@ function! s:setup_options() abort
     endif
     let options = [
         \ ['autoclose', 0],
-        \ ['autoclose_netrw', 1],
+        \ ['autoclose_netrw', 0],
         \ ['autofocus', 0],
         \ ['autopreview', 0],
         \ ['autoshowtag', 0],


### PR DESCRIPTION
Changing the default value of `g:tagbar_autoclose_netrw` to 0 based on community feedback. More people seem to be in favor of having this value as false as a default.