### PR TITLE
Replace vim-easytags link with vim-gutentags in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ the class they are defined in.
 Tagbar is not a general-purpose tool for managing `tags` files. It only
 creates the tags it needs on-the-fly in-memory without creating any files.
 `tags` file management is provided by other plugins, like for example
-[easytags](https://github.com/xolox/vim-easytags).
+[gutentags](https://github.com/ludovicchabant/vim-gutentags).
 
 ## Dependencies
 


### PR DESCRIPTION
Since [vim-easytags](https://github.com/xolox/vim-easytags) has not been updated in seven years, it would be best to point users to [vim-gutentags](https://github.com/ludovicchabant/vim-gutentags) for a vim plugin that manages your tags automatically, as that is being actively maintained.