### PR TITLE
Add support for biblatex

### DIFF
--- a/autoload/tagbar/types/uctags.vim
+++ b/autoload/tagbar/types/uctags.vim
@@ -209,6 +209,49 @@ function! tagbar#types#uctags#init(supported_types) abort
     \ ]
     let types.bibtex = type_bibtex
     let types.bib = type_bibtex
+    " BibLaTex {{{1
+    let type_biblatex = tagbar#prototypes#typeinfo#new()
+    let type_biblatex.ctagstype = 'biblatex'
+    let type_biblatex.kinds = [
+        \ {'short' : 'A', 'long' : 'artworks', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'B', 'long' : 'audios', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'C', 'long' : 'bibnotes', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'D', 'long' : 'bookinbooks', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'E', 'long' : 'Booklets', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'G', 'long' : 'collections', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'H', 'long' : 'commentarys', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'I', 'long' : 'datasets', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'J', 'long' : 'images', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'K', 'long' : 'interferences', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'L', 'long' : 'jurisdictions', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'M', 'long' : 'legislations', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'N', 'long' : 'legals', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'O', 'long' : 'letters', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'P', 'long' : 'movies', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'Q', 'long' : 'musics', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'R', 'long' : 'mvbooks', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'S', 'long' : 'mvcollections', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'T', 'long' : 'mvproceedings', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'U', 'long' : 'mvreferences', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'V', 'long' : 'onlines', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'W', 'long' : 'patents', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'g', 'long' : 'performances', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'h', 'long' : 'periodicals', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'i', 'long' : 'references', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'j', 'long' : 'reports', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'k', 'long' : 'reviews', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'l', 'long' : 'sets', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'm', 'long' : 'software', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'n', 'long' : 'standards', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'o', 'long' : 'suppbooks', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'p', 'long' : 'suppcollections', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'q', 'long' : 'suppperiodicals', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'r', 'long' : 'thesis', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 's', 'long' : 'videos', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 't', 'long' : 'xdatas', 'fold' : 0, 'stl' : 0},
+    \ ]
+    let types.biblatex = type_biblatex
+    let types.bib = type_biblatex
     " C {{{1
     let type_c = tagbar#prototypes#typeinfo#new()
     let type_c.ctagstype = 'c'

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -1509,6 +1509,7 @@ former allows simple regular expression-based parsing that is easy to get
 started with, but doesn't support scopes unless you instead want to write a
 C-based parser module for Exuberant Ctags. The regex approach is described in
 more detail below.
+
 Writing your own program is the approach used by for example jsctags and can
 be useful if your language can best be parsed by a program written in the
 language itself, or if you want to provide the program as part of a complete
@@ -1519,6 +1520,28 @@ Before writing your own extension have a look at the wiki
 (https://github.com/preservim/tagbar/wiki) or try googling for existing ones.
 If you do end up creating your own extension please consider adding it to the
 wiki so that others can benefit from it, too.
+
+In some cases there may be a definition for the filetype defined, but vim may
+not recognize the extension. For example, the BibLaTeX file format is defined
+separately from the BibTeX support for universal-ctags. So there are two defined
+language types in tagbar. However VIM does not have a specific extension that
+is recognized for the BibLaTeX filetype. In these cases it is necessary to add
+a custom filetype extension definition in your .vim configuration.
+
+For example:
+>
+        $ cat ~/.vim/filetype.vim
+        " custom filetypes
+
+        augroup filetypedetect
+            au! BufRead,BufNewFile *.biblatex setfiletype biblatex
+        augroup END
+        $
+<
+
+This will automatically detect the file extension of *.biblatex and define the
+filetype in VIM as a biblatex filetype so tagbar will correctly identify the
+filetype and use the correct definition.
 
 Every type definition in Tagbar is a dictionary with the following keys:
 


### PR DESCRIPTION
Fixes #856

Note: VIM does not have a known file extension to differentiate between `.bib` and a BibLaTeX file. From what I can see, there is no common file-extension for a BibLaTeX file, so a custom filetype configuration will be needed in vim to differentiate between the two.