### PR TITLE
Merge bibtex and biblatex as much as possible

### DIFF
--- a/autoload/tagbar/types/uctags.vim
+++ b/autoload/tagbar/types/uctags.vim
@@ -206,6 +206,31 @@ function! tagbar#types#uctags#init(supported_types) abort
         \ {'short' : 's', 'long' : 'string', 'fold' : 0, 'stl' : 0},
         \ {'short' : 't', 'long' : 'techreport', 'fold' : 0, 'stl' : 0},
         \ {'short' : 'u', 'long' : 'unpublished', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'A', 'long' : 'artworks', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'C', 'long' : 'bibnotes', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'D', 'long' : 'bookinbooks', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'E', 'long' : 'Booklets', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'G', 'long' : 'collections', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'H', 'long' : 'commentarys', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'J', 'long' : 'images', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'K', 'long' : 'interferences', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'L', 'long' : 'jurisdictions', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'N', 'long' : 'legals', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'O', 'long' : 'letters', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'Q', 'long' : 'musics', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'R', 'long' : 'mvbooks', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'S', 'long' : 'mvcollections', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'T', 'long' : 'mvproceedings', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'U', 'long' : 'mvreferences', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'V', 'long' : 'onlines', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'W', 'long' : 'patents', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'g', 'long' : 'performances', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'h', 'long' : 'periodicals', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'k', 'long' : 'reviews', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'l', 'long' : 'sets', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'o', 'long' : 'suppbooks', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'q', 'long' : 'suppperiodicals', 'fold' : 0, 'stl' : 0},
+        \ {'short' : 'r', 'long' : 'thesis', 'fold' : 0, 'stl' : 0},
     \ ]
     let types.bibtex = type_bibtex
     let types.bib = type_bibtex
@@ -251,7 +276,6 @@ function! tagbar#types#uctags#init(supported_types) abort
         \ {'short' : 't', 'long' : 'xdatas', 'fold' : 0, 'stl' : 0},
     \ ]
     let types.biblatex = type_biblatex
-    let types.bib = type_biblatex
     " C {{{1
     let type_c = tagbar#prototypes#typeinfo#new()
     let type_c.ctagstype = 'c'


### PR DESCRIPTION
Closes #856

The universal-ctags update includes both the bibtex and biblatex parser when processing a .bib file even when language is forced. This will merge the two as much as possible. There are a number of conflicts and will use the bibtex standard type in that instance.