### PR TITLE
fix: 'g:tagbar_autoclose_netrw' was not actually really default to 0

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -3521,13 +3521,15 @@ function! s:HandleOnlyWindow() abort
 
     let file_open = s:HasOpenFileWindows()
 
-    if vim_quitting && file_open == 2 && !g:tagbar_autoclose_netrw
-        call tagbar#debug#log('Closing Tagbar due to QuitPre - netrw only remaining window')
-        call s:CloseWindow()
+    if vim_quitting && file_open == 2
+        if g:tagbar_autoclose_netrw
+            call tagbar#debug#log('Closing Tagbar due to QuitPre - netrw only remaining window')
+            call s:CloseWindow()
+        endif
         return
     endif
 
-    if vim_quitting && file_open != 1
+    if vim_quitting && file_open == 0
         call tagbar#debug#log('Closing Tagbar window due to QuitPre event')
         if winnr('$') >= 1
             call s:goto_win(tagbarwinnr, 1)


### PR DESCRIPTION
https://github.com/preservim/tagbar/pull/822
it seems did not actually really reset the default value to 0, 
or just the init and doc, but the logic still was 1.
// and the logic seems was not correct, try to fix.
