### PR TITLE
Allow custom language definitions

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -232,18 +232,18 @@ endfunction
 function! s:InitTypes() abort
     call tagbar#debug#log('Initializing types')
 
-    let supported_types = s:GetSupportedFiletypes()
+    let s:supported_types = s:GetSupportedFiletypes()
 
     if s:ctags_is_uctags
-        let s:known_types = tagbar#types#uctags#init(supported_types)
+        let s:known_types = tagbar#types#uctags#init(s:supported_types)
     else
-        let s:known_types = tagbar#types#ctags#init(supported_types)
+        let s:known_types = tagbar#types#ctags#init(s:supported_types)
     endif
 
     " Use dart_ctags if available
     let dart_ctags = s:CheckFTCtags('dart_ctags', 'dart')
     if dart_ctags !=# ''
-        let supported_types['dart'] = 1
+        let s:supported_types['dart'] = 1
         call tagbar#debug#log('Detected dart_ctags, overriding typedef')
         let type_dart = tagbar#prototypes#typeinfo#new()
         let type_dart.ctagstype = 'dart'
@@ -806,14 +806,14 @@ function! s:GetSupportedFiletypes() abort
 
     let types = split(ctags_output, '\n\+')
 
-    let supported_types = {}
+    let ctags_supported_types = {}
     for type in types
         if match(type, '\[disabled\]') == -1
-            let supported_types[tolower(type)] = 1
+            let ctags_supported_types[tolower(type)] = 1
         endif
     endfor
 
-    return supported_types
+    return ctags_supported_types
 endfunction
 
 " Known files {{{1
@@ -1422,8 +1422,7 @@ function! s:ExecuteCtagsOnFile(fname, realfname, typeinfo) abort
             " Must define custom languages before --language-force
             if has_key(a:typeinfo, 'deffile') && filereadable(expand(a:typeinfo.deffile))
                 " check if ftype is a custom language (unknown to ctags)
-                let supported_types = s:GetSupportedFiletypes()
-                if has_key(a:typeinfo, 'ftype') && !has_key(supported_types, a:typeinfo.ftype)
+                if has_key(a:typeinfo, 'ftype') && !has_key(s:supported_types, a:typeinfo.ftype)
                     let ctags_args += ['--options=' . expand(a:typeinfo.deffile)]
                 endif
             endif

--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1408,12 +1408,6 @@ function! s:ExecuteCtagsOnFile(fname, realfname, typeinfo) abort
             let ctags_args += [ '-V' ]
         endif
 
-        " Include extra type definitions - include here to allow for custom
-        " language definitions
-        if has_key(a:typeinfo, 'deffile') && filereadable(expand(a:typeinfo.deffile))
-            let ctags_args += ['--options=' . expand(a:typeinfo.deffile)]
-        endif
-
         " Third-party programs may not necessarily make use of this
         if has_key(a:typeinfo, 'ctagstype')
             let ctags_type = a:typeinfo.ctagstype
@@ -1424,6 +1418,15 @@ function! s:ExecuteCtagsOnFile(fname, realfname, typeinfo) abort
                     let ctags_kinds .= kind.short
                 endif
             endfor
+
+            " Must define custom languages before --language-force
+            if has_key(a:typeinfo, 'deffile') && filereadable(expand(a:typeinfo.deffile))
+                " check if ftype is a custom language (unknown to ctags)
+                let supported_types = s:GetSupportedFiletypes()
+                if has_key(a:typeinfo, 'ftype') && !has_key(supported_types, a:typeinfo.ftype)
+                    let ctags_args += ['--options=' . expand(a:typeinfo.deffile)]
+                endif
+            endif
 
             let ctags_args += ['--language-force=' . ctags_type]
             let ctags_args += ['--' . ctags_type . '-kinds=' . ctags_kinds]

--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1408,6 +1408,12 @@ function! s:ExecuteCtagsOnFile(fname, realfname, typeinfo) abort
             let ctags_args += [ '-V' ]
         endif
 
+        " Include extra type definitions - include here to allow for custom
+        " language definitions
+        if has_key(a:typeinfo, 'deffile') && filereadable(expand(a:typeinfo.deffile))
+            let ctags_args += ['--options=' . expand(a:typeinfo.deffile)]
+        endif
+
         " Third-party programs may not necessarily make use of this
         if has_key(a:typeinfo, 'ctagstype')
             let ctags_type = a:typeinfo.ctagstype


### PR DESCRIPTION
Fixes #789 

This PR adds a second duplicate `--option` directive to the `ctags` command, using `deffile` twice. The first `--option` comes prior to `--language-force` and lets ctags know the custom language. The second `--option` comes last to override the default `--kinds-<lang>` definition.

This PR addresses the same problem that #792 addresses, but in a different way that doesn't require additional user options.

This fix needs testing, especially on the use case described in #776.