### PR TITLE
Correct the behavior of the custom ctagsbin override

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -771,19 +771,18 @@ endfunction
 
 " s:CheckFTCtags() {{{2
 function! s:CheckFTCtags(bin, ftype) abort
-    if executable(a:bin)
-        return a:bin
-    endif
-
     if exists('g:tagbar_type_' . a:ftype)
         let userdef = g:tagbar_type_{a:ftype}
-        if has_key(userdef, 'ctagsbin')
-            return userdef.ctagsbin
-        else
+        if has_key(userdef, 'kinds')
             return ''
+        elseif has_key(userdef, 'ctagsbin')
+            return userdef.ctagsbin
         endif
     endif
 
+    if executable(a:bin)
+        return a:bin
+    endif
     return ''
 endfunction
 


### PR DESCRIPTION
Closes #878

In the event the user has defined a custom ctagsbin for a specific type, and they have also defined the `kinds`, then we do not want to override that choice. Instead only override the `kinds` if the custom ctagsbin is set without the `kinds` being provided.