### PR TITLE
Add program, package and interface to systemverilog scopes

### DIFF
--- a/autoload/tagbar/types/uctags.vim
+++ b/autoload/tagbar/types/uctags.vim
@@ -1372,11 +1372,17 @@ function! tagbar#types#uctags#init(supported_types) abort
         \ 'E' : 'enum',
         \ 'C' : 'class',
         \ 'm' : 'module',
+        \ 'P' : 'program',
+        \ 'K' : 'package',
+        \ 'I' : 'interface',
     \ }
     let type_systemverilog.scope2kind = {
         \ 'enum'     : 'E',
         \ 'class'    : 'C',
         \ 'module'   : 'm',
+        \ 'program'  : 'P',
+        \ 'package'  : 'K',
+        \ 'interface': 'I',
     \ }
     let types.systemverilog = type_systemverilog
     " VHDL {{{1


### PR DESCRIPTION
Adds additional scopes to systemverilog 
- `program` is a kind of module for testbenches
     * https://www.chipverify.com/systemverilog/systemverilog-program-block
- `package`  for definition scopes
     * https://www.chipverify.com/systemverilog/systemverilog-package
- `interface` which encapsulates signals, tasks...
     * https://www.chipverify.com/systemverilog/systemverilog-interface