### PR TITLE
This adds support for controlling display of suffix/prefix

### DIFF
--- a/autoload/tagbar/prototypes/basetag.vim
+++ b/autoload/tagbar/prototypes/basetag.vim
@@ -84,7 +84,7 @@ endfunction
 function! s:_getPrefix() abort dict
     let fileinfo = self.fileinfo
 
-    if !empty(self._childlist)
+    if !empty(self._childlist) && g:tagbar_show_prefix == 1
         if fileinfo.tagfolds[self.fields.kind][self.fullpath]
             let prefix = g:tagbar#icon_closed
         else
@@ -95,9 +95,9 @@ function! s:_getPrefix() abort dict
     endif
     " Visibility is called 'access' in the ctags output
     if g:tagbar_show_visibility
-        if has_key(self.fields, 'access')
+        if has_key(self.fields, 'access') && g:tagbar_show_prefix == 1
             let prefix .= get(s:visibility_symbols, self.fields.access, ' ')
-        elseif has_key(self.fields, 'file')
+        elseif has_key(self.fields, 'file') && g:tagbar_show_prefix == 1
             let prefix .= s:visibility_symbols.private
         else
             let prefix .= ' '

--- a/autoload/tagbar/prototypes/normaltag.vim
+++ b/autoload/tagbar/prototypes/normaltag.vim
@@ -28,19 +28,28 @@ endfunction
 function! s:strfmt() abort dict
     let typeinfo = self.typeinfo
 
-    let suffix = get(self.fields, 'signature', '')
-    if has_key(self.fields, 'type')
-        let suffix .= ' : ' . self.fields.type
-    elseif has_key(get(typeinfo, 'kind2scope', {}), self.fields.kind)
-        let scope = s:maybe_map_scope(typeinfo.kind2scope[self.fields.kind])
-        if !g:tagbar_show_data_type
-            let suffix .= ' : ' . scope
+    if g:tagbar_show_suffix == 1
+        let suffix = get(self.fields, 'signature', '')
+        if has_key(self.fields, 'type')
+            let suffix .= ' : ' . self.fields.type
+        elseif has_key(get(typeinfo, 'kind2scope', {}), self.fields.kind)
+            let scope = s:maybe_map_scope(typeinfo.kind2scope[self.fields.kind])
+            if !g:tagbar_show_data_type
+                let suffix .= ' : ' . scope
+            endif
         endif
-    endif
-    let prefix = self._getPrefix()
 
-    if g:tagbar_show_data_type && self.getDataType() !=# ''
-        let suffix .= ' : ' . self.getDataType()
+        if g:tagbar_show_data_type && self.getDataType() !=# ''
+            let suffix .= ' : ' . self.getDataType()
+        endif
+    else
+        let suffix = ''
+    endif
+
+    if g:tagbar_show_prefix == 1
+        let prefix = self._getPrefix()
+    else
+        let prefix = ''
     endif
 
     if g:tagbar_show_tag_linenumbers == 1

--- a/autoload/tagbar/prototypes/normaltag.vim
+++ b/autoload/tagbar/prototypes/normaltag.vim
@@ -46,11 +46,7 @@ function! s:strfmt() abort dict
         let suffix = ''
     endif
 
-    if g:tagbar_show_prefix == 1
-        let prefix = self._getPrefix()
-    else
-        let prefix = ''
-    endif
+    let prefix = self._getPrefix()
 
     if g:tagbar_show_tag_linenumbers == 1
         let suffix .= ' [' . self.fields.line . ']'

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -821,6 +821,37 @@ Example:
 >
         let g:tagbar_show_linenumbers = 2
 <
+                                                          *g:tagbar_show_prefix*
+g:tagbar_show_prefix~
+Default: 1
+
+Controls if the prefix information is shown before the tag. The prefix info is
+usually defined as the variable scope. For example, if a variable is private
+scope only, then a '-' symbol will be used by default.
+
+Possible values are:
+  0: Don't show the prefix.
+  1: Show the prefix.
+
+Example:
+>
+        let g:tagbar_show_prefix = 0
+<
+                                                          *g:tagbar_show_suffix*
+g:tagbar_show_suffix~
+Default: 1
+
+Controls if the suffix information is shown after the tag. The suffix info is
+usually data type.
+
+Possible values are:
+  0: Don't show the suffix.
+  1: Show the suffix.
+
+Example:
+>
+        let g:tagbar_show_suffix = 0
+<
                                                  *g:tagbar_show_tag_linenumbers*
 g:tagbar_show_tag_linenumbers~
 Default: 0

--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -113,6 +113,8 @@ function! s:setup_options() abort
         \ ['show_data_type', 0],
         \ ['show_visibility', 1],
         \ ['show_linenumbers', 0],
+        \ ['show_prefix', 1],
+        \ ['show_suffix', 1],
         \ ['show_tag_count', 0],
         \ ['show_tag_linenumbers', 0],
         \ ['singleclick', 0],


### PR DESCRIPTION
Fixes #870

This adds the `g:tagbar_show_prefix` and `g:tagbar_show_suffix` options. These will help control if the prefix info and/or suffix info is printed in the tagbar window for the tag.

This is just test code for now.