### PR TITLE
Running tagbar with airline broke TagbarCurrent

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -328,17 +328,17 @@ function! s:InitTypes() abort
         let type_go = tagbar#prototypes#typeinfo#new()
         let type_go.ctagstype = 'go'
         let type_go.kinds = [
-            \ {'short' : 'p', 'long' : 'package',      'fold' : 0, 'stl' : 0},
-            \ {'short' : 'i', 'long' : 'imports',      'fold' : 1, 'stl' : 0},
+            \ {'short' : 'p', 'long' : 'package',      'fold' : 0, 'stl' : 1},
+            \ {'short' : 'i', 'long' : 'imports',      'fold' : 1, 'stl' : 1},
             \ {'short' : 'c', 'long' : 'constants',    'fold' : 0, 'stl' : 0},
             \ {'short' : 'v', 'long' : 'variables',    'fold' : 0, 'stl' : 0},
-            \ {'short' : 't', 'long' : 'types',        'fold' : 0, 'stl' : 0},
+            \ {'short' : 't', 'long' : 'types',        'fold' : 0, 'stl' : 1},
             \ {'short' : 'n', 'long' : 'intefaces',    'fold' : 0, 'stl' : 0},
-            \ {'short' : 'w', 'long' : 'fields',       'fold' : 0, 'stl' : 0},
+            \ {'short' : 'w', 'long' : 'fields',       'fold' : 0, 'stl' : 1},
             \ {'short' : 'e', 'long' : 'embedded',     'fold' : 0, 'stl' : 0},
             \ {'short' : 'm', 'long' : 'methods',      'fold' : 0, 'stl' : 0},
             \ {'short' : 'r', 'long' : 'constructors', 'fold' : 0, 'stl' : 0},
-            \ {'short' : 'f', 'long' : 'functions',    'fold' : 0, 'stl' : 0},
+            \ {'short' : 'f', 'long' : 'functions',    'fold' : 0, 'stl' : 1},
         \ ]
         let type_go.sro        = '.'
         let type_go.kind2scope = {


### PR DESCRIPTION
- It seems that airline initialize with uctags kinds table but after that call also call InitTypes but that has wrong values.