### PR TITLE
Higher tolerance for splitting tag line

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -1319,7 +1319,7 @@ function! s:ProcessFile(fname, ftype) abort
 
         let seen[line] = 1
 
-        let parts = split(line, ';"')
+        let parts = split(line, ';"\t')
         if len(parts) == 2 " Is a valid tag line
             call s:ParseTagline(parts[0], parts[1], typeinfo, fileinfo)
         endif
@@ -1509,7 +1509,7 @@ function! s:ParseTagline(part1, part2, typeinfo, fileinfo) abort
 
     " When splitting fields make sure not to create empty keys or values in
     " case a value illegally contains tabs
-    let fields = split(a:part2, '^\t\|\t\ze\w\+:')
+    let fields = split(a:part2, '\t\ze\w\+:')
     let fielddict = {}
     if fields[0] !~# ':'
         let fielddict.kind = remove(fields, 0)

--- a/doc/tagbar.txt
+++ b/doc/tagbar.txt
@@ -2089,7 +2089,7 @@ tracking HEAD in the default branch rather than tagged releases.
     - Periodic rollup, see `git log v3.0.0..v3.1.1`
 
 3.1.0 (2022-11-04)
-    - Periodic rollup (inclomplete merge, suggest 3.1.1)
+    - Periodic rollup (incomplete merge, suggest 3.1.1)
 
 3.0.0 (2021-01-21)
     - Massive rollup with years of small changes, see `git log v2.7..v3.0.0`


### PR DESCRIPTION
This is a very small patch, use `;"\t` to split tags line instead of `;"`. Using `;"` to split tags line will cause tagbar to ignore those tags which `;"` in the current line. It is indeed possible to have `;"` in a line of a file, such as a string `";"`, or a similar string ending with `;` such as html entity (like `"&semi;"`), or included in the end-of-line _comments_, etc. But the probability of `;"\t` appearing in a code file is much smaller. In addition, the patch fix a typo that was seen.