### PR TITLE
Set g:loaded_tagbar on plugin load, not autoload

### DIFF
--- a/autoload/tagbar.vim
+++ b/autoload/tagbar.vim
@@ -78,8 +78,6 @@ let s:window_pos = {
 
 let s:delayed_update_files = []
 
-let g:loaded_tagbar = 1
-
 let s:last_highlight_tline = 0
 
 let s:warnings = {

--- a/plugin/tagbar.vim
+++ b/plugin/tagbar.vim
@@ -42,6 +42,8 @@ if v:version == 700 && !has('patch167')
     finish
 endif
 
+let g:loaded_tagbar = 1
+
 function! s:init_var(var, value) abort
     if !exists('g:tagbar_' . a:var)
         execute 'let g:tagbar_' . a:var . ' = ' . string(a:value)


### PR DESCRIPTION
By setting this in autoload it is not set on plugin load, which means other plugins or scripts (e.g. in ~/.vim/plugin/after) cannot check it.